### PR TITLE
Fixed diagnosis and healthy control bug

### DIFF
--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -28,7 +28,7 @@ export default {
   props: {
     results: {
       type: Array,
-      required: true,
+      default: () => [],
     },
     downloads: {
       type: Array,

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -161,7 +161,7 @@ export default {
       if (this.sex) {
         url += `&sex=${this.sex}`;
       }
-      if (this.diagnosis) {
+      if (this.diagnosis && !this.is_control) {
         url += `&diagnosis=${this.diagnosis}`;
       }
       if (this.is_control) {


### PR DESCRIPTION
Main change:
- Fixed the bug which Closes #58 
- Changed the `results` prop in DownloadResultsButton.vue to not be required and set its default to empty array
   - To resolve the vue warning regarding `results` prop type check