### PR TITLE
[MAINT] Updated dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'nuxt'
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closes #73 
See also #72

Changes proposed in this pull request:

- Updated dependabot.yml with instructions to ignore nuxt major version updates
