### PR TITLE
[ENH] Modified tool for new dataset-level and subject-level results

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ To define a cohort, set your inclusion criteria using the following:
 
 
 Once you've defined your criteria, submit them as a query and the query tool will display the results.\
-The query tool offers two different CSV files for results:
-- Dataset-level results csv contains: dataset portal uri, dataset file path, dataset name, number of matching subjects, and available imaging modalities
-- Subject-level results csv contains: dataset file path, subject id, age, sex, diagnosis, session id, session file path, number of sessions, and imaging modality
+The query tool offers two different TSV files for results:
+- Dataset-level results TSV contains: dataset portal uri, dataset file path, dataset name, number of matching subjects, and available imaging modalities
+- Participant-level results TSV contains: dataset file path, subject id, age, sex, diagnosis, session id, session file path, number of sessions, and imaging modality
 
-You can choose which file to download by checking and uncehcking the `Toggle Results CSV` checkbox above the `Download Results` button.
+You can choose which file to download by checking and uncehcking the `Toggle Results TSV` checkbox above the `Download Results` button.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ To define a cohort, set your inclusion criteria using the following:
 - Modality: Imaging modality of participant scans that should be included in the results.
 
 
-Once you've defined your criteria, submit them as a query and the query tool will display the results.
+Once you've defined your criteria, submit them as a query and the query tool will display the results.\
+The query tool offers two different CSV files for results:
+- Dataset-level results csv contains: dataset portal uri, dataset file path, dataset name, number of matching subjects, and available imaging modalities
+- Subject-level results csv contains: dataset file path, subject id, age, sex, diagnosis, session id, session file path, number of sessions, and imaging modality
+
+You can choose which file to download by checking and uncehcking the `Toggle Results CSV` checkbox above the `Download Results` button.
 
 ## Testing
 

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -16,7 +16,7 @@
         >
         <label
           class="form-label"
-        >Toggle Results TSV</label>
+        >Toggle level of detail to download</label>
       </b-col>
 
       <b-button

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -5,8 +5,18 @@
     style="margin-top: 1em;"
   >
     <b-row
-      class="mr-auto"
+      class="flex-column"
     >
+      <b-col>
+        <input
+          class="form-check-input"
+          type="checkbox"
+        >
+        <label
+          class="form-label"
+        >Toggle Results CSV</label>
+      </b-col>
+
       <b-button
         id="download-results-button"
         :disabled="downloads.length === 0"

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -106,7 +106,11 @@ export default {
       const element = document.createElement('a');
       element.setAttribute('href', `data:text/tsv;charset=utf-8,
       ${encodeURIComponent(this.generateTSVString())}`);
-      element.setAttribute('download', 'results.tsv');
+      if (this.toggleResultsTSV) {
+        element.setAttribute('download', 'participant-results.tsv');
+      } else {
+        element.setAttribute('download', 'dataset-results.tsv');
+      }
 
       element.style.display = 'none';
       document.body.appendChild(element);

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -9,14 +9,14 @@
     >
       <b-col>
         <input
-          v-model="toggleCSV"
-          data-cy="toggle-csv-checkbox"
+          v-model="toggleResultsTSV"
+          data-cy="toggle-tsv-checkbox"
           class="form-check-input"
           type="checkbox"
         >
         <label
           class="form-label"
-        >Toggle Results CSV</label>
+        >Toggle Results TSV</label>
       </b-col>
 
       <b-button
@@ -49,7 +49,7 @@ export default {
   },
   data() {
     return {
-      toggleCSV: false,
+      toggleResultsTSV: false,
     };
   },
   computed: {
@@ -59,54 +59,54 @@ export default {
   },
   methods: {
     toggleDownloadResultsButtonText() {
-      return this.toggleCSV ? 'Download Subject-level Results' : 'Download Dataset-level Results';
+      return this.toggleResultsTSV ? 'Download Participant-level Results' : 'Download Dataset-level Results';
     },
-    generateCSVString() {
-      const csvRows = [];
+    generateTSVString() {
+      const tsvRows = [];
       const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_name));
 
-      if (this.toggleCSV) {
-        const headers = ['DatasetFilePath', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'];
-        csvRows.push(headers);
+      if (this.toggleResultsTSV) {
+        const headers = ['DatasetFilePath', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'].join('\t');
+        tsvRows.push(headers);
 
         datasets.forEach((res) => {
           res.subject_data.forEach((subject) => {
-            csvRows.push([
+            tsvRows.push([
               res.dataset_file_path,
               subject.sub_id,
               subject.age,
               subject.sex,
-              subject.diagnosis?.join('  '),
+              subject.diagnosis?.join(', '),
               subject.session_id,
               subject.session_file_path,
               subject.num_sessions,
-              subject.image_modal?.join('  '),
-            ].join(','));
+              subject.image_modal?.join(', '),
+            ].join('\t'));
           });
         });
       } else {
-        const headers = ['PortalURI', 'DatasetFilePath', 'DatasetName', 'NumMatchingSubjects', 'AvailableImageModalities'];
-        csvRows.push(headers);
+        const headers = ['PortalURI', 'DatasetFilePath', 'DatasetName', 'NumMatchingSubjects', 'AvailableImageModalities'].join('\t');
+        tsvRows.push(headers);
 
         datasets.forEach((res) => {
-          csvRows.push([
+          tsvRows.push([
             res.dataset_portal_uri,
             res.dataset_file_path,
             res.dataset_name,
             res.num_matching_subjects,
-            res.image_modals.join('  '),
-          ].join(','));
+            res.image_modals.join(', '),
+          ].join('\t'));
         });
       }
 
-      return csvRows.join('\n');
+      return tsvRows.join('\n');
     },
 
     downloadResults() {
       const element = document.createElement('a');
-      element.setAttribute('href', `data:text/csv;charset=utf-8,
-      ${encodeURIComponent(this.generateCSVString())}`);
-      element.setAttribute('download', 'results.csv');
+      element.setAttribute('href', `data:text/tsv;charset=utf-8,
+      ${encodeURIComponent(this.generateTSVString())}`);
+      element.setAttribute('download', 'results.tsv');
 
       element.style.display = 'none';
       document.body.appendChild(element);

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -61,19 +61,42 @@ export default {
       return this.toggleCSV ? 'Download Subject-level Results' : 'Download Dataset-level Results';
     },
     generateCSVString() {
-      const headers = ['dataset', 'number of matching subjects', 'subject data'];
-      const csvRows = [headers];
+      const csvRows = [];
+      const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_name));
 
-      this.results.filter((res) => this.downloads.includes(res.dataset_name))
-        .forEach((res) => {
-          res.subject_data.forEach((path) => {
+      if (this.toggleCSV) {
+        const headers = ['DatasetFilePath', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'];
+        csvRows.push(headers);
+
+        datasets.forEach((res) => {
+          res.subject_data.forEach((subject) => {
             csvRows.push([
-              res.dataset_name,
-              res.num_matching_subjects,
-              path,
+              res.dataset_file_path,
+              subject.sub_id,
+              subject.age,
+              subject.sex,
+              subject.diagnosis?.join('  '),
+              subject.session_id,
+              subject.session_file_path,
+              subject.num_sessions,
+              subject.image_modal?.join('  '),
             ].join(','));
           });
         });
+      } else {
+        const headers = ['PortalURI', 'DatasetFilePath', 'DatasetName', 'NumMatchingSubjects', 'AvailableImageModalities'];
+        csvRows.push(headers);
+
+        datasets.forEach((res) => {
+          csvRows.push([
+            res.dataset_portal_uri,
+            res.dataset_file_path,
+            res.dataset_name,
+            res.num_matching_subjects,
+            res.image_modals.join('  '),
+          ].join(','));
+        });
+      }
 
       return csvRows.join('\n');
     },

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -9,6 +9,7 @@
     >
       <b-col>
         <input
+          v-model="toggleCSV"
           class="form-check-input"
           type="checkbox"
         >
@@ -27,7 +28,7 @@
           icon="download"
           font-scale="1"
         />
-        Download Results
+        {{ toggleDownloadResultsButtonText() }}
       </b-button>
     </b-row>
   </b-col>
@@ -45,12 +46,20 @@ export default {
       default: () => [],
     },
   },
+  data() {
+    return {
+      toggleCSV: false,
+    };
+  },
   computed: {
     displayDownloadResultsButton() {
       return !Object.is(this.results, null) && this.results.length !== 0;
     },
   },
   methods: {
+    toggleDownloadResultsButtonText() {
+      return this.toggleCSV ? 'Download Subject-level Results' : 'Download Dataset-level Results';
+    },
     generateCSVString() {
       const headers = ['dataset', 'number of matching subjects', 'subject data'];
       const csvRows = [headers];

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -10,6 +10,7 @@
       <b-col>
         <input
           v-model="toggleCSV"
+          data-cy="toggle-csv-checkbox"
           class="form-check-input"
           type="checkbox"
         >

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -29,7 +29,7 @@
           icon="download"
           font-scale="1"
         />
-        {{ toggleDownloadResultsButtonText() }}
+        {{ toggleDownloadResultsButtonText }}
       </b-button>
     </b-row>
   </b-col>
@@ -56,11 +56,11 @@ export default {
     displayDownloadResultsButton() {
       return !Object.is(this.results, null) && this.results.length !== 0;
     },
-  },
-  methods: {
     toggleDownloadResultsButtonText() {
       return this.toggleResultsTSV ? 'Download Participant-level Results' : 'Download Dataset-level Results';
     },
+  },
+  methods: {
     generateTSVString() {
       const tsvRows = [];
       const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_name));

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -77,6 +77,7 @@
           type="submit"
           data-cy="submit-query"
         >
+        <b-spinner v-if="isFetching" small></b-spinner>
           Submit Query
         </b-button>
       </b-form>
@@ -103,6 +104,7 @@ export default {
       min_num_sessions: null,
       assessment: null,
       modality: null,
+      isFetching: false,
     };
   },
   methods: {
@@ -151,6 +153,7 @@ export default {
       }
     },
     async submitQuery() {
+      this.isFetching = true;
       let url = `${process.env.API_QUERY_URL}query/?`;
       if (this.minAge) {
         url += `min_age=${this.minAge}`;
@@ -182,6 +185,7 @@ export default {
       } catch (err) {
         this.$emit('update-response', null, 'Oops, something went wrong');
       }
+      this.isFetching = false;
     },
   },
 };

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -77,7 +77,10 @@
           type="submit"
           data-cy="submit-query"
         >
-        <b-spinner v-if="isFetching" small></b-spinner>
+          <b-spinner
+            v-if="isFetching"
+            small
+          />
           Submit Query
         </b-button>
       </b-form>

--- a/cypress/component/DownloadResultsButton.cy.js
+++ b/cypress/component/DownloadResultsButton.cy.js
@@ -35,19 +35,19 @@ describe('Download results button', () => {
     });
     cy.get('[data-cy="download-results-button"]').should('be.visible').should('not.be.disabled');
   });
-  it('Displays the toggle results csv checkbox', () => {
+  it('Displays the toggle results tsv checkbox', () => {
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
-    cy.get('[data-cy="toggle-csv-checkbox"]').should('be.visible');
+    cy.get('[data-cy="toggle-tsv-checkbox"]').should('be.visible');
   });
   it("Changes the download results button's text when the box is checked and unchecked", () => {
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
-    cy.get('[data-cy="toggle-csv-checkbox"]').check();
-    cy.get('[data-cy="download-results-button"]').contains('Download Subject-level Results');
-    cy.get('[data-cy="toggle-csv-checkbox"]').uncheck();
+    cy.get('[data-cy="toggle-tsv-checkbox"]').check();
+    cy.get('[data-cy="download-results-button"]').contains('Download Participant-level Results');
+    cy.get('[data-cy="toggle-tsv-checkbox"]').uncheck();
     cy.get('[data-cy="download-results-button"]').contains('Download Dataset-level Results');
   });
 });

--- a/cypress/component/DownloadResultsButton.cy.js
+++ b/cypress/component/DownloadResultsButton.cy.js
@@ -35,4 +35,19 @@ describe('Download results button', () => {
     });
     cy.get('[data-cy="download-results-button"]').should('be.visible').should('not.be.disabled');
   });
+  it('Displays the toggle results csv checkbox', () => {
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
+    cy.get('[data-cy="toggle-csv-checkbox"]').should('be.visible');
+  });
+  it("Changes the download results button's text when the box is checked and unchecked", () => {
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
+    cy.get('[data-cy="toggle-csv-checkbox"]').check();
+    cy.get('[data-cy="download-results-button"]').contains('Download Subject-level Results');
+    cy.get('[data-cy="toggle-csv-checkbox"]').uncheck();
+    cy.get('[data-cy="download-results-button"]').contains('Download Dataset-level Results');
+  });
 });


### PR DESCRIPTION
Closes #76
Closes https://github.com/neurobagel/project/issues/118

Changes proposed in this pull request:
- Implemented Checkbox to toggle results csv
- Modified `generateCSVString` method to return new dataset-level and subject-level results (the two .csv files).
- Updated `DownloadResultsButton` component test
- Update README.md to mention what the tool now returns based on the status of the checkbox
- Implemented spinner fo the submit query button

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
