### PR TITLE
[BUG] Fixed team feedback bugs

### DIFF
--- a/components/ContinuousField.vue
+++ b/components/ContinuousField.vue
@@ -9,7 +9,7 @@
       type="number"
       :step="step"
       class="numberinput form-control"
-      min="0"
+      :min="min"
       @input="updateField"
     />
   </div>
@@ -18,6 +18,10 @@
 <script>
 export default {
   props: {
+    min: {
+      type: String,
+      default: '0',
+    },
     name: {
       type: String,
       required: true,

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -92,9 +92,9 @@ export default {
           tsvRows.push([
             res.dataset_portal_uri,
             res.dataset_file_path,
-            res.dataset_name,
+            res.dataset_name.replace('\n', ' '),
             res.num_matching_subjects,
-            res.image_modals.join(', '),
+            res.image_modals?.join(', '),
           ].join('\t'));
         });
       }
@@ -104,7 +104,7 @@ export default {
 
     downloadResults() {
       const element = document.createElement('a');
-      element.setAttribute('href', `data:text/tsv;charset=utf-8,
+      element.setAttribute('href', `data:text/tab-separated-values;charset=utf-8,
       ${encodeURIComponent(this.generateTSVString())}`);
       if (this.toggleResultsTSV) {
         element.setAttribute('download', 'participant-results.tsv');

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -150,7 +150,9 @@ export default {
     },
     validateQueryForm() {
       if (this.minAge && this.maxAge && Number(this.minAge) > Number(this.maxAge)) {
-        this.displayToast('Maximum age must be greater than or equal to minimum age');
+        this.displayToast('The value of maximum age field must be greater than or equal to the value of minimum age field');
+      } else if (this.min_num_sessions === '0') {
+        this.displayToast('The value for minimum number of sessions field must be greater than 0');
       } else {
         this.submitQuery();
       }

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -53,6 +53,7 @@
           </template>
         </categorical-field>
         <continuous-field
+          min="1"
           name="Minimum number of sessions"
           data-cy="min-num-sessions-field"
           step="1"
@@ -151,8 +152,6 @@ export default {
     validateQueryForm() {
       if (this.minAge && this.maxAge && Number(this.minAge) > Number(this.maxAge)) {
         this.displayToast('The value of maximum age field must be greater than or equal to the value of minimum age field');
-      } else if (this.min_num_sessions === '0') {
-        this.displayToast('The value for minimum number of sessions field must be greater than 0');
       } else {
         this.submitQuery();
       }

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -66,11 +66,5 @@ describe('Query form', () => {
     cy.get('[data-cy="submit-query"]').click();
     // See https://stackoverflow.com/questions/71295432/unable-to-see-toast-in-cypress/71301155#71301155
     cy.contains('#b-toaster-top-right', 'The value of maximum age field must be greater than or equal to the value of minimum age field');
-
-    cy.get('[data-cy="Min Age-continuous-field-input"]').clear();
-    cy.get('[data-cy="Max Age-continuous-field-input"]').clear();
-    cy.get('[data-cy="Minimum number of sessions-continuous-field-input"]').type(0);
-    cy.get('[data-cy="submit-query"]').click();
-    cy.contains('#b-toaster-top-right', 'The value for minimum number of sessions field must be greater than 0');
   });
 });

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -65,6 +65,12 @@ describe('Query form', () => {
     cy.get('[data-cy="Max Age-continuous-field-input"]').type(3);
     cy.get('[data-cy="submit-query"]').click();
     // See https://stackoverflow.com/questions/71295432/unable-to-see-toast-in-cypress/71301155#71301155
-    cy.contains('#b-toaster-top-right', 'Maximum age must be greater than or equal to minimum age');
+    cy.contains('#b-toaster-top-right', 'The value of maximum age field must be greater than or equal to the value of minimum age field');
+
+    cy.get('[data-cy="Min Age-continuous-field-input"]').clear();
+    cy.get('[data-cy="Max Age-continuous-field-input"]').clear();
+    cy.get('[data-cy="Minimum number of sessions-continuous-field-input"]').type(0);
+    cy.get('[data-cy="submit-query"]').click();
+    cy.contains('#b-toaster-top-right', 'The value for minimum number of sessions field must be greater than 0');
   });
 });

--- a/cypress/e2e/DatasetResultsTSV.cy.js
+++ b/cypress/e2e/DatasetResultsTSV.cy.js
@@ -1,0 +1,21 @@
+const response = [
+  {
+    dataset_portal_uri: 'https://someportal.org/datasets/ds0001',
+    dataset_file_path: 'https://github.com/somethingDatasets/ds0001.git',
+    dataset_name: 'some\nname',
+    num_matching_subjects: 3,
+    subject_data: [],
+    image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
+  },
+];
+
+describe('Dataset results TSV', () => {
+  it('Intercepts the request sent to the API and asserts over the request url', () => {
+    cy.intercept('query/?*', response).as('call');
+    cy.visit('/');
+    cy.get('[data-cy="submit-query"]').click();
+    cy.get('[data-cy="select-all"]').check();
+    cy.get('[data-cy="download-results-button"]').click();
+    cy.readFile('cypress/downloads/dataset-results.tsv').should('not.contain', 'some\nname');
+  });
+});

--- a/cypress/e2e/DatasetResultsTSV.cy.js
+++ b/cypress/e2e/DatasetResultsTSV.cy.js
@@ -10,12 +10,12 @@ const response = [
 ];
 
 describe('Dataset results TSV', () => {
-  it('Intercepts the request sent to the API and asserts over the request url', () => {
+  it('Removes a newline character from a dataset name in the downloaded results file', () => {
     cy.intercept('query/?*', response).as('call');
     cy.visit('/');
     cy.get('[data-cy="submit-query"]').click();
     cy.get('[data-cy="select-all"]').check();
     cy.get('[data-cy="download-results-button"]').click();
-    cy.readFile('cypress/downloads/dataset-results.tsv').should('not.contain', 'some\nname');
+    cy.readFile('cypress/downloads/dataset-results.tsv').should('contain', 'some name');
   });
 });


### PR DESCRIPTION
Fixes neurobagel/old-query-tool#95 
Fixes neurobagel/old-query-tool#96 
See also neurobagel/query-tool#70 

Changes proposed in this pull request:

- Implemented a condition to give an error message via toast when the value of the minimum number of sessions is set to 0 in `validateQueryForm` 
- Implemented a test case for the above in the `QueryForm` component test
- Implemented a quick fix for neurobagel/old-query-tool#96, to replace `\n` escape character in `dataset_name` with a space
- Implemented `DatasetResultsTSV` e2e test for the above

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
