### PR TITLE
[ENH]: add breakpoints

### DIFF
--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-col cols="12" md="4" xl="3">
+  <b-col cols="12" md="4" xl="2">
     <b-row>
       <h2>Query fields</h2>
     </b-row>

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -1,6 +1,5 @@
 <template>
-  <b-col cols="12" md="4" xl="3"
-  >
+  <b-col cols="12" md="4" xl="3">
     <b-row>
       <h2>Query fields</h2>
     </b-row>

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -1,6 +1,5 @@
 <template>
-  <b-col
-    cols="2"
+  <b-col cols="12" md="4" xl="3"
   >
     <b-row>
       <h2>Query fields</h2>

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-col cols="12" md="8" xl="9">
+  <b-col cols="12" md="8" xl="10">
     <b-row>
       <h2>Results</h2>
     </b-row>

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <b-col
-    cols="10"
+    cols="12" md="8" xl="9"
   >
     <b-row>
       <h2>Results</h2>

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -1,7 +1,5 @@
 <template>
-  <b-col
-    cols="12" md="8" xl="9"
-  >
+  <b-col cols="12" md="8" xl="9">
     <b-row>
       <h2>Results</h2>
     </b-row>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -156,4 +156,11 @@ export default {
 .toast:not(.show) {
    display: block;
 }
+
+/** Vue select */
+.vs__clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 </style>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add breakpoints to `QueryForm` and `ResultsContainer` so they will not break on mobile
- Change column sizes for large screens so the UI will not break on smaller "xl" screens. For example, on my 13" Macbook, the query panel is very small and the "Healthy control" checkbox overflows.
- Center the X to clear the categorical field so it is aligned with the dropdown indicator
- 
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
