### PR TITLE
[BUG] Fixed inconsistent behaviour of checkboxes

### DIFF
--- a/components/ResultCard.vue
+++ b/components/ResultCard.vue
@@ -14,7 +14,7 @@
                   class="form-check-input dataset-checkbox"
                   type="checkbox"
                   value=""
-                  :checked="selectAll"
+                  :checked="isChecked"
                   :data-cy="`card-${datasetName}-checkbox`"
                   @change="updateDownloads"
                 >
@@ -86,7 +86,7 @@ export default {
       type: Array,
       default: null,
     },
-    selectAll: {
+    isChecked: {
       type: Boolean,
       default: false,
     },
@@ -125,8 +125,8 @@ export default {
     };
   },
   methods: {
-    updateDownloads() {
-      this.$emit('update-downloads', this.datasetName, this.$refs.checkbox.checked);
+    updateDownloads(event) {
+      this.$emit('update-downloads', this.datasetName, event.target.checked);
     },
   },
 };

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -112,6 +112,12 @@ export default {
       return !Object.is(this.results, null) && this.results.length !== 0;
     },
   },
+  watch: {
+    results() {
+      this.downloads = [];
+    },
+
+  },
   methods: {
     summarizeStats() {
       let datasets = 0;

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -71,11 +71,11 @@
       <b-list-group id="results-list-group">
         <result-card
           v-for="res in results"
-          :key="res.id"
+          :key="res.dataset_uuid"
           :dataset-name="res.dataset_name"
           :num-matching-subjects="res.num_matching_subjects"
           :image-modals="res.image_modals"
-          :select-all="selectAll"
+          :is-checked="selectAll"
           :data-cy="res.dataset_name"
           @update-downloads="updateDownloads"
         />

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -114,6 +114,7 @@ export default {
   },
   watch: {
     results() {
+      this.selectAll = false;
       this.downloads = [];
     },
 

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -75,7 +75,7 @@
           :dataset-name="res.dataset_name"
           :num-matching-subjects="res.num_matching_subjects"
           :image-modals="res.image_modals"
-          :is-checked="selectAll"
+          :is-checked="selectAll || downloads.includes(res.dataset_name)"
           :data-cy="res.dataset_name"
           @update-downloads="updateDownloads"
         />

--- a/cypress/component/ResultCard.cy.js
+++ b/cypress/component/ResultCard.cy.js
@@ -4,7 +4,7 @@ const props = {
   datasetName: 'cool-dataset',
   numMatchingSubjects: 4,
   imageModals: ['http://purl.org/nidash/nidm#T1Weighted', 'http://purl.org/nidash/nidm#T2Weighted'],
-  selectAll: true,
+  isChecked: true,
 };
 
 describe('Result card', () => {

--- a/cypress/e2e/Checkbox.cy.js
+++ b/cypress/e2e/Checkbox.cy.js
@@ -30,6 +30,8 @@ const response2 = [
 
 describe('Checkbox', () => {
   it('Unchecks checked checkboxes after a second query is run.', () => {
+    // Since the defualt viewport results in partial occlusion of the checkbox
+    // Set the viewport to 2000x1000 to ensure the checkbox is not covered and is cliclable
     cy.viewport(2000, 1000);
 
     let isFirstClick = true;

--- a/cypress/e2e/Checkbox.cy.js
+++ b/cypress/e2e/Checkbox.cy.js
@@ -1,0 +1,52 @@
+const response = [
+  {
+    dataset_uuid: 'http://neurobagel.org/vocab/000d0851-c72e-462d-9457-9ab97ced7d45',
+    dataset_name: 'thoughtExperiment',
+    dataset_portal_uri: 'https://openneuro.org/datasets/ds001419',
+    num_matching_subjects: 3,
+    subject_data: [],
+    image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
+  },
+];
+
+const response2 = [
+  {
+    dataset_uuid: 'http://neurobagel.org/vocab/000d0851-c72e-462d-9457-9ab97ced7d',
+    dataset_name: 'Some cool dataset',
+    dataset_portal_uri: 'https://openneuro.org/datasets/ds001417',
+    num_matching_subjects: 5,
+    subject_data: [],
+    image_modals: ['http://purl.org/nidash/nidm#FlowWeighted'],
+  },
+  {
+    dataset_uuid: 'http://neurobagel.org/vocab/000d0851-c72e-462d-9457-9ab97ced7d45',
+    dataset_name: 'thoughtExperiment',
+    dataset_portal_uri: 'https://openneuro.org/datasets/ds001419',
+    num_matching_subjects: 3,
+    subject_data: [],
+    image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
+  },
+];
+
+describe('Checkbox', () => {
+  it('Unchecks checked checkboxes after a second query is run.', () => {
+    cy.viewport(2000, 1000);
+
+    let isFirstClick = true;
+
+    cy.intercept('GET', 'query/*', (req) => {
+      if (isFirstClick) {
+        isFirstClick = false;
+        req.reply(response);
+      } else {
+        req.reply(response2);
+      }
+    });
+
+    cy.visit('/');
+    cy.get('[data-cy="submit-query"]').click();
+    cy.get('[data-cy="card-thoughtExperiment-checkbox"]').check();
+    cy.get('[data-cy="submit-query"]').click();
+    cy.get('[data-cy="card-thoughtExperiment-checkbox"]').should('not.be.checked');
+  });
+});

--- a/cypress/e2e/DatasetResultsTSV.cy.js
+++ b/cypress/e2e/DatasetResultsTSV.cy.js
@@ -1,6 +1,6 @@
 const response = [
   {
-    dataset_portal_uri: 'https://someportal.org/datasets/ds0001',
+    dataset_uuid: 'https://someportal.org/datasets/ds0001',
     dataset_file_path: 'https://github.com/somethingDatasets/ds0001.git',
     dataset_name: 'some\nname',
     num_matching_subjects: 3,


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #124 
Closes #134 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

- Renamed `selectAll` prop to `isChecked` in the `ResultCard` component
- `updateDownloads` method now uses `event` instead of `refs` in the `ResultCard` component
- Changed the `v-for` `key` to `dataset_uuid` in the `ResultsContainer` component
- Modified the value of the `is-checked` prop passed to `ResultCard` in `ResultsContainer` to check if the `datasetName` is already in the `downloads` array or is `selectAll` set to `true`
- Implemented an integration test to ensure the `downloads` array is wiped every time a query is run
  - documented here in [wiki](https://github.com/neurobagel/documentation/wiki/Cypress-Test-Snippets#provide-different-responses-based-on-a-condition-when-intercepting-requests)
- Implemented a watcher in `ResultsContainer` to wipe the `downloads` array every time `results` is changed i.e. a new query is submitted
- Updated `ResultCard` component test

## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
