### PR TITLE
[MAINT] Updated navbar `version` link

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -28,7 +28,7 @@
           class="ml-auto"
         >
           <b-nav-item
-            href="https://github.com/neurobagel/query-tool/tree/v0.1.0/"
+            href="https://github.com/neurobagel/query-tool/releases/tag/v0.1.0"
             target="_blank"
             data-cy="version"
           >

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -28,7 +28,7 @@
           class="ml-auto"
         >
           <b-nav-item
-            href="https://github.com/neurobagel/query-tool/releases/tag/v0.1.0"
+            href="https://github.com/neurobagel/query-tool/releases/tag/v0.1.0/"
             target="_blank"
             data-cy="version"
           >

--- a/cypress/component/Navbar.cy.js
+++ b/cypress/component/Navbar.cy.js
@@ -10,7 +10,7 @@ describe('Navbar', () => {
     cy.get('[data-cy="version"]').should('be.visible');
     cy.get('[data-cy="version"]').contains('v0.1.0');
     cy.get('[data-cy="version"]').within(() => {
-      cy.get('a').should('have.attr', 'href', 'https://github.com/neurobagel/query-tool/tree/v0.1.0/');
+      cy.get('a').should('have.attr', 'href', 'https://github.com/neurobagel/query-tool/releases/tag/v0.1.0/');
     });
     cy.get('[data-cy="docs"]').should('be.visible');
     cy.get('[data-cy="docs"]').contains('Documentation');

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -98,5 +98,3 @@ export default {
 
 };
 </script>
-<style>
-</style>


### PR DESCRIPTION
Changes proposed in this pull request:

- Updated navbar `version` link to point to release notes instead of the branch
- Removed `style` tag from `index.vue`

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
