### PR TITLE
[BUG] Modified components to use `dataset_uuid` as identifier

### DIFF
--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -56,7 +56,7 @@ export default {
   methods: {
     generateTSVString(buttonIdentifier) {
       const tsvRows = [];
-      const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_name));
+      const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_uuid));
 
       if (buttonIdentifier === 'participant-level') {
         const headers = ['DatasetID', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'Assessment', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'].join('\t');

--- a/components/ResultCard.vue
+++ b/components/ResultCard.vue
@@ -15,7 +15,7 @@
                   type="checkbox"
                   value=""
                   :checked="isChecked"
-                  :data-cy="`card-${datasetName}-checkbox`"
+                  :data-cy="`card-${datasetId}-checkbox`"
                   @change="updateDownloads"
                 >
               </b-col>
@@ -26,7 +26,7 @@
                 <b-row>
                   <h5
                     class="card-title"
-                    :data-cy="`card-${datasetName}-dataset`"
+                    :data-cy="`card-${datasetId}-dataset`"
                   >
                     {{ datasetName }}
                   </h5>
@@ -35,7 +35,7 @@
                   <b-col cols="6">
                     <p
                       class="card-text"
-                      :data-cy="`card-${datasetName}-subjects`"
+                      :data-cy="`card-${datasetId}-subjects`"
                     >
                       {{ `${numMatchingSubjects} subjects` }}
                     </p>
@@ -58,7 +58,7 @@
                     type="button"
                     class="btn card-modality"
                     :style="modalities[modality].style"
-                    :data-cy="`card-${datasetName}-${modalities[modality].name}`"
+                    :data-cy="`card-${datasetId}-${modalities[modality].name}`"
                   >
                     {{ modalities[modality].name }}
                   </b-button>
@@ -74,6 +74,10 @@
 <script>
 export default {
   props: {
+    datasetId: {
+      type: String,
+      required: true,
+    },
     datasetName: {
       type: String,
       required: true,
@@ -126,7 +130,7 @@ export default {
   },
   methods: {
     updateDownloads(event) {
-      this.$emit('update-downloads', this.datasetName, event.target.checked);
+      this.$emit('update-downloads', this.datasetId, event.target.checked);
     },
   },
 };

--- a/components/ResultCard.vue
+++ b/components/ResultCard.vue
@@ -15,7 +15,7 @@
                   type="checkbox"
                   value=""
                   :checked="isChecked"
-                  :data-cy="`card-${datasetId}-checkbox`"
+                  :data-cy="`card-${datasetUuid}-checkbox`"
                   @change="updateDownloads"
                 >
               </b-col>
@@ -26,7 +26,7 @@
                 <b-row>
                   <h5
                     class="card-title"
-                    :data-cy="`card-${datasetId}-dataset`"
+                    :data-cy="`card-${datasetUuid}-dataset`"
                   >
                     {{ datasetName }}
                   </h5>
@@ -35,7 +35,7 @@
                   <b-col cols="6">
                     <p
                       class="card-text"
-                      :data-cy="`card-${datasetId}-subjects`"
+                      :data-cy="`card-${datasetUuid}-subjects`"
                     >
                       {{ `${numMatchingSubjects} subjects` }}
                     </p>
@@ -58,7 +58,7 @@
                     type="button"
                     class="btn card-modality"
                     :style="modalities[modality].style"
-                    :data-cy="`card-${datasetId}-${modalities[modality].name}`"
+                    :data-cy="`card-${datasetUuid}-${modalities[modality].name}`"
                   >
                     {{ modalities[modality].name }}
                   </b-button>
@@ -74,7 +74,7 @@
 <script>
 export default {
   props: {
-    datasetId: {
+    datasetUuid: {
       type: String,
       required: true,
     },
@@ -130,7 +130,7 @@ export default {
   },
   methods: {
     updateDownloads(event) {
-      this.$emit('update-downloads', this.datasetId, event.target.checked);
+      this.$emit('update-downloads', this.datasetUuid, event.target.checked);
     },
   },
 };

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -72,7 +72,7 @@
         <result-card
           v-for="res in results"
           :key="res.dataset_uuid"
-          :dataset-id="res.dataset_uuid"
+          :dataset-uuid="res.dataset_uuid"
           :dataset-name="res.dataset_name"
           :num-matching-subjects="res.num_matching_subjects"
           :image-modals="res.image_modals"
@@ -141,11 +141,11 @@ export default {
         this.downloads = [];
       }
     },
-    updateDownloads(datasetId, checked) {
+    updateDownloads(datasetUuid, checked) {
       if (checked) {
-        this.downloads.push(datasetId);
+        this.downloads.push(datasetUuid);
       } else {
-        this.downloads = this.downloads.filter((item) => item !== datasetId);
+        this.downloads = this.downloads.filter((item) => item !== datasetUuid);
       }
     },
   },

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -46,7 +46,7 @@
           type="checkbox"
           value=""
           data-cy="select-all"
-          @change="UpdateDownloadsSelectAll"
+          @change="updateDownloadsSelectAll"
         >
         <label
           for="dataset-checkall"
@@ -72,11 +72,12 @@
         <result-card
           v-for="res in results"
           :key="res.dataset_uuid"
+          :dataset-id="res.dataset_uuid"
           :dataset-name="res.dataset_name"
           :num-matching-subjects="res.num_matching_subjects"
           :image-modals="res.image_modals"
-          :is-checked="selectAll || downloads.includes(res.dataset_name)"
-          :data-cy="res.dataset_name"
+          :is-checked="selectAll || downloads.includes(res.dataset_uuid)"
+          :data-cy="res.dataset_uuid"
           @update-downloads="updateDownloads"
         />
       </b-list-group>
@@ -129,22 +130,22 @@ export default {
       });
       return `Summary stats: ${datasets} datasets, ${subjects} subjects`;
     },
-    UpdateDownloadsSelectAll() {
+    updateDownloadsSelectAll() {
       if (this.selectAll) {
         this.results.forEach((res) => {
-          if (!this.downloads.includes(res.dataset_name)) {
-            this.downloads.push(res.dataset_name);
+          if (!this.downloads.includes(res.dataset_uuid)) {
+            this.downloads.push(res.dataset_uuid);
           }
         });
       } else {
         this.downloads = [];
       }
     },
-    updateDownloads(datasetName, checked) {
+    updateDownloads(datasetId, checked) {
       if (checked) {
-        this.downloads.push(datasetName);
+        this.downloads.push(datasetId);
       } else {
-        this.downloads = this.downloads.filter((item) => item !== datasetName);
+        this.downloads = this.downloads.filter((item) => item !== datasetId);
       }
     },
   },

--- a/cypress/component/ResultCard.cy.js
+++ b/cypress/component/ResultCard.cy.js
@@ -1,7 +1,7 @@
 import ResultCard from '../../components/ResultCard.vue';
 
 const props = {
-  datasetId: 'http://neurobagel.org/vocab/cool-dataset',
+  datasetUuid: 'http://neurobagel.org/vocab/cool-dataset',
   datasetName: 'cool-dataset',
   numMatchingSubjects: 4,
   imageModals: ['http://purl.org/nidash/nidm#T1Weighted', 'http://purl.org/nidash/nidm#T2Weighted'],

--- a/cypress/component/ResultCard.cy.js
+++ b/cypress/component/ResultCard.cy.js
@@ -1,6 +1,7 @@
 import ResultCard from '../../components/ResultCard.vue';
 
 const props = {
+  datasetId: 'http://neurobagel.org/vocab/cool-dataset',
   datasetName: 'cool-dataset',
   numMatchingSubjects: 4,
   imageModals: ['http://purl.org/nidash/nidm#T1Weighted', 'http://purl.org/nidash/nidm#T2Weighted'],
@@ -12,11 +13,11 @@ describe('Result card', () => {
     cy.mount(ResultCard, {
       propsData: props,
     });
-    cy.get('[data-cy="card-cool-dataset-dataset"]').should('be.visible').contains('cool-dataset');
-    cy.get('[data-cy="card-cool-dataset-subjects"]').should('be.visible').contains('4 subjects');
-    cy.get('[data-cy="card-cool-dataset-T1"]').should('be.visible').contains('T1');
-    cy.get('[data-cy="card-cool-dataset-T2"]').should('be.visible').contains('T2');
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').should('be.visible').should('be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-dataset"]').should('be.visible').contains('cool-dataset');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-subjects"]').should('be.visible').contains('4 subjects');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-T1"]').should('be.visible').contains('T1');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-T2"]').should('be.visible').contains('T2');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').should('be.visible').should('be.checked');
   });
   it('Emits update-download when a checkbox is checked/unchecked', () => {
     cy.viewport(2000, 1000);
@@ -26,9 +27,9 @@ describe('Result card', () => {
       },
       propsData: props,
     });
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').uncheck();
-    cy.get('@spy').should('have.been.calledWith', 'cool-dataset', false);
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').check();
-    cy.get('@spy').should('have.been.calledWith', 'cool-dataset', true);
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').uncheck();
+    cy.get('@spy').should('have.been.calledWith', 'http://neurobagel.org/vocab/cool-dataset', false);
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').check();
+    cy.get('@spy').should('have.been.calledWith', 'http://neurobagel.org/vocab/cool-dataset', true);
   });
 });

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -10,14 +10,14 @@ const stubs = {
 const props = {
   results: [
     {
-      dataset: 'http://neurobagel.org/vocab/cool-dataset',
+      dataset_uuid: 'http://neurobagel.org/vocab/cool-dataset',
       dataset_name: 'cool-dataset',
       num_matching_subjects: 2,
       subject_file_paths: ['cool-path', 'some-cool-path'],
       image_modals: ['http://purl.org/nidash/nidm#T1Weighted', 'http://purl.org/nidash/nidm#T2Weighted'],
     },
     {
-      dataset: 'http://neurobagel.org/vocab/not-so-cool-dataset',
+      dataset_uuid: 'http://neurobagel.org/vocab/not-so-cool-dataset',
       dataset_name: 'not-so-cool-dataset',
       num_matching_subjects: 2,
       subject_file_paths: ['not-so-cool-path', 'some-not-so-cool-path'],
@@ -56,12 +56,12 @@ describe('Results', () => {
     });
     cy.get('[data-cy="select-all"]').should('be.visible').check();
     cy.get('[data-cy="select-all"]').should('be.checked');
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').should('be.checked');
-    cy.get('[data-cy="card-not-so-cool-dataset-checkbox"]').should('be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').should('be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/not-so-cool-dataset-checkbox"]').should('be.checked');
     cy.get('[data-cy="select-all"]').uncheck();
     cy.get('[data-cy="select-all"]').should('not.be.checked');
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').should('not.be.checked');
-    cy.get('[data-cy="card-not-so-cool-dataset-checkbox"]').should('not.be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').should('not.be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/not-so-cool-dataset-checkbox"]').should('not.be.checked');
   });
   it('Displays the summary stats', () => {
     cy.mount(ResultsContainer, {
@@ -74,8 +74,8 @@ describe('Results', () => {
       stubs,
       propsData: props,
     });
-    cy.get('[data-cy="cool-dataset"]').should('be.visible');
-    cy.get('[data-cy="not-so-cool-dataset"]').should('be.visible');
+    cy.get('[data-cy="http://neurobagel.org/vocab/cool-dataset"]').should('be.visible');
+    cy.get('[data-cy="http://neurobagel.org/vocab/not-so-cool-dataset"]').should('be.visible');
   });
   it('Displays download results buttons (and its component) and enables/disables it by checking/unchecking checkboxes', () => {
     cy.viewport(2000, 1000);
@@ -89,10 +89,10 @@ describe('Results', () => {
     cy.get('[data-cy="select-all"]').check();
     cy.get('[data-cy="download-participant-level-results-button"]').should('not.be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('not.be.disabled');
-    cy.get('[data-cy="card-cool-dataset-checkbox"]').uncheck();
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').uncheck();
     cy.get('[data-cy="download-participant-level-results-button"]').should('not.be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('not.be.disabled');
-    cy.get('[data-cy="card-not-so-cool-dataset-checkbox"]').uncheck();
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/not-so-cool-dataset-checkbox"]').uncheck();
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
   });

--- a/cypress/e2e/Checkbox.cy.js
+++ b/cypress/e2e/Checkbox.cy.js
@@ -47,8 +47,8 @@ describe('Checkbox', () => {
 
     cy.visit('/');
     cy.get('[data-cy="submit-query"]').click();
-    cy.get('[data-cy="card-thoughtExperiment-checkbox"]').check();
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/000d0851-c72e-462d-9457-9ab97ced7d45-checkbox"]').check();
     cy.get('[data-cy="submit-query"]').click();
-    cy.get('[data-cy="card-thoughtExperiment-checkbox"]').should('not.be.checked');
+    cy.get('[data-cy="card-http://neurobagel.org/vocab/000d0851-c72e-462d-9457-9ab97ced7d45-checkbox"]').should('not.be.checked');
   });
 });

--- a/cypress/e2e/DatasetResultsTSV.cy.js
+++ b/cypress/e2e/DatasetResultsTSV.cy.js
@@ -11,6 +11,7 @@ const response = [
 
 describe('Dataset results TSV', () => {
   it('Removes a newline character from a dataset name in the downloaded dataset-level results file', () => {
+    cy.viewport(2000, 1000);
     cy.intercept('query/?*', response).as('call');
     cy.visit('/');
     cy.get('[data-cy="submit-query"]').click();


### PR DESCRIPTION
Closes #153 

Changes proposed in this pull request:

- Implemented `datasetId` prop as an identifier for datasets
- Modified `data-cy` attribute of elements to use `datasetId`
- Updated `updateDownloads` method
- Updated `updateDownloadsSelectAll` method
- Modified `generateTSVString` method to use `dataset_uuid` for filtering the `results` array
- Updated tests

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
