### PR TITLE
[ENH] Implemented tooltips for download results buttons

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -124,6 +124,10 @@ input[type="checkbox"]:checked {
   display: block;
 }
 
+.tooltip-inner {
+  background-color: #470A68;
+}
+
 /* Vue select */
 .vs__clear {
   display: flex;

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -6,31 +6,35 @@
   >
     <b-row>
       <div class="d-flex">
-        <b-button
-          class="nb-button"
-          :disabled="downloads.length === 0"
-          data-cy="download-participant-level-results-button"
-          @click="downloadResults('participant-level')"
-        >
-          <b-icon
-            icon="download"
-            font-scale="1"
-          />
-          Download Participant-level Results
-        </b-button>
+        <span v-b-tooltip.hover.top="displayToolTip">
+          <b-button
+            class="nb-button"
+            :disabled="downloads.length === 0"
+            data-cy="download-participant-level-results-button"
+            @click="downloadResults('participant-level')"
+          >
+            <b-icon
+              icon="download"
+              font-scale="1"
+            />
+            Download Participant-level Results
+          </b-button>
+        </span>
 
-        <b-button
-          class="nb-button download-dataset-level-results-button"
-          :disabled="downloads.length === 0"
-          data-cy="download-dataset-level-results-button"
-          @click="downloadResults('dataset-level')"
-        >
-          <b-icon
-            icon="download"
-            font-scale="1"
-          />
-          Download Dataset-level Results
-        </b-button>
+        <span v-b-tooltip.hover.top="displayToolTip">
+          <b-button
+            class="nb-button download-dataset-level-results-button"
+            :disabled="downloads.length === 0"
+            data-cy="download-dataset-level-results-button"
+            @click="downloadResults('dataset-level')"
+          >
+            <b-icon
+              icon="download"
+              font-scale="1"
+            />
+            Download Dataset-level Results
+          </b-button>
+        </span>
       </div>
     </b-row>
   </b-col>
@@ -51,6 +55,9 @@ export default {
   computed: {
     displayDownloadResultsButton() {
       return !Object.is(this.results, null) && this.results.length !== 0;
+    },
+    displayToolTip() {
+      return this.downloads.length === 0 ? 'Select at least one dataset for download' : '';
     },
   },
   methods: {

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -6,7 +6,10 @@
   >
     <b-row>
       <div class="d-flex">
-        <span v-b-tooltip.hover.top="displayToolTip">
+        <span
+          v-b-tooltip.hover.top="displayToolTip"
+          data-cy="download-participant-level-results-button-tooltip"
+        >
           <b-button
             class="nb-button"
             :disabled="downloads.length === 0"
@@ -21,7 +24,10 @@
           </b-button>
         </span>
 
-        <span v-b-tooltip.hover.top="displayToolTip">
+        <span
+          v-b-tooltip.hover.top="displayToolTip"
+          data-cy="download-dataset-level-results-button-tooltip"
+        >
           <b-button
             class="nb-button download-dataset-level-results-button"
             :disabled="downloads.length === 0"

--- a/cypress/component/DownloadResultsButton.cy.js
+++ b/cypress/component/DownloadResultsButton.cy.js
@@ -37,4 +37,24 @@ describe('Download results button', () => {
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.visible').should('not.be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.visible').should('not.be.disabled');
   });
+  it('Displays the tooltips when the download results buttons are disabled', () => {
+    props.downloads = [];
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
+    cy.get('[data-cy="download-participant-level-results-button"]')
+      .first()
+      .trigger('mouseenter', { force: true });
+
+    cy.get('[data-cy="download-participant-level-results-button-tooltip"]')
+      .should('be.visible')
+      .trigger('mouseleave');
+
+    cy.get('[data-cy="download-dataset-level-results-button"]')
+      .first()
+      .trigger('mouseenter', { force: true });
+
+    cy.get('[data-cy="download-dataset-level-results-button-tooltip"]')
+      .should('be.visible');
+  });
 });


### PR DESCRIPTION
Closes #128 

Changes proposed in this pull request:
- Implemented tooltips for download results buttons
- Implemented test for the tooltips

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
