### PR TITLE
[MAINT] Refactored `DownloadResultsButton` into a generic component

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -99,7 +99,7 @@
   background-color: #2d0644;
 }
 
-.download-dataset-level-results-button {
+.download-buttons-div > *:not(:first-child) {
   margin-left: 0.25em;
 }
 

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -1,13 +1,13 @@
 <template>
   <span
-    v-b-tooltip.hover.top="displayToolTip"
+    v-b-tooltip.hover.top="downloadsIsEmpty ? 'Select at least one dataset for download' : ''"
     :data-cy="`download-` + identifier + `-results-button-tooltip`"
   >
     <b-button
       class="nb-button"
-      :disabled="downloads.length === 0"
+      :disabled="downloadsIsEmpty"
       :data-cy="`download-` + identifier + `-results-button`"
-      @click="downloadResults(identifier)"
+      @click="$emit('download-results', identifier)"
     >
       <b-icon
         icon="download"
@@ -25,75 +25,11 @@ export default {
       type: String,
       default: 'participant-level',
     },
-    results: {
-      type: Array,
-      default: () => [],
-    },
-    downloads: {
-      type: Array,
-      default: () => [],
+    downloadsIsEmpty: {
+      type: Boolean,
+      default: true,
     },
   },
-  computed: {
-    displayToolTip() {
-      return this.downloads.length === 0 ? 'Select at least one dataset for download' : '';
-    },
-  },
-  methods: {
-    generateTSVString(buttonIdentifier) {
-      const tsvRows = [];
-      const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_uuid));
-
-      if (buttonIdentifier === 'participant-level') {
-        const headers = ['DatasetID', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'Assessment', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'].join('\t');
-        tsvRows.push(headers);
-
-        datasets.forEach((res) => {
-          res.subject_data.forEach((subject) => {
-            tsvRows.push([
-              res.dataset_uuid,
-              subject.sub_id,
-              subject.age,
-              subject.sex,
-              subject.diagnosis?.join(', '),
-              subject.assessment?.join(', '),
-              subject.session_id,
-              subject.session_file_path,
-              subject.num_sessions,
-              subject.image_modal?.join(', '),
-            ].join('\t'));
-          });
-        });
-      } else {
-        const headers = ['DatasetID', 'DatasetName', 'PortalURI', 'NumMatchingSubjects', 'AvailableImageModalities'].join('\t');
-        tsvRows.push(headers);
-
-        datasets.forEach((res) => {
-          tsvRows.push([
-            res.dataset_uuid,
-            res.dataset_name.replace('\n', ' '),
-            res.dataset_portal_uri,
-            res.num_matching_subjects,
-            res.image_modals?.join(', '),
-          ].join('\t'));
-        });
-      }
-
-      return tsvRows.join('\n');
-    },
-
-    downloadResults(buttonIdentifier) {
-      const element = document.createElement('a');
-      const encodedTSV = encodeURIComponent(this.generateTSVString(buttonIdentifier));
-      element.setAttribute('href', `data:text/tab-separated-values;charset=utf-8,${encodedTSV}`);
-      element.setAttribute('download', `${buttonIdentifier}-results.tsv`);
-
-      element.style.display = 'none';
-      document.body.appendChild(element);
-
-      element.click();
-      document.body.removeChild(element);
-    },
-  },
+  emits: ['download-results'],
 };
 </script>

--- a/components/DownloadResultsButton.vue
+++ b/components/DownloadResultsButton.vue
@@ -1,54 +1,30 @@
 <template>
-  <b-col
-    v-if="displayDownloadResultsButton"
-    class="d-flex flex-row-reverse"
-    style="margin-top: 1em;"
+  <span
+    v-b-tooltip.hover.top="displayToolTip"
+    :data-cy="`download-` + identifier + `-results-button-tooltip`"
   >
-    <b-row>
-      <div class="d-flex">
-        <span
-          v-b-tooltip.hover.top="displayToolTip"
-          data-cy="download-participant-level-results-button-tooltip"
-        >
-          <b-button
-            class="nb-button"
-            :disabled="downloads.length === 0"
-            data-cy="download-participant-level-results-button"
-            @click="downloadResults('participant-level')"
-          >
-            <b-icon
-              icon="download"
-              font-scale="1"
-            />
-            Download Participant-level Results
-          </b-button>
-        </span>
-
-        <span
-          v-b-tooltip.hover.top="displayToolTip"
-          data-cy="download-dataset-level-results-button-tooltip"
-        >
-          <b-button
-            class="nb-button download-dataset-level-results-button"
-            :disabled="downloads.length === 0"
-            data-cy="download-dataset-level-results-button"
-            @click="downloadResults('dataset-level')"
-          >
-            <b-icon
-              icon="download"
-              font-scale="1"
-            />
-            Download Dataset-level Results
-          </b-button>
-        </span>
-      </div>
-    </b-row>
-  </b-col>
+    <b-button
+      class="nb-button"
+      :disabled="downloads.length === 0"
+      :data-cy="`download-` + identifier + `-results-button`"
+      @click="downloadResults(identifier)"
+    >
+      <b-icon
+        icon="download"
+        font-scale="1"
+      />
+      {{ 'Download ' + identifier + ' results' }}
+    </b-button>
+  </span>
 </template>
 
 <script>
 export default {
   props: {
+    identifier: {
+      type: String,
+      default: 'participant-level',
+    },
     results: {
       type: Array,
       default: () => [],
@@ -59,9 +35,6 @@ export default {
     },
   },
   computed: {
-    displayDownloadResultsButton() {
-      return !Object.is(this.results, null) && this.results.length !== 0;
-    },
     displayToolTip() {
       return this.downloads.length === 0 ? 'Select at least one dataset for download' : '';
     },
@@ -113,11 +86,7 @@ export default {
       const element = document.createElement('a');
       const encodedTSV = encodeURIComponent(this.generateTSVString(buttonIdentifier));
       element.setAttribute('href', `data:text/tab-separated-values;charset=utf-8,${encodedTSV}`);
-      if (buttonIdentifier === 'participant-level') {
-        element.setAttribute('download', 'participant-results.tsv');
-      } else {
-        element.setAttribute('download', 'dataset-results.tsv');
-      }
+      element.setAttribute('download', `${buttonIdentifier}-results.tsv`);
 
       element.style.display = 'none';
       document.body.appendChild(element);

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -91,15 +91,15 @@
         <div class="download-buttons-div d-flex">
           <download-results-button
             identifier="participant-level"
-            :results="results"
-            :downloads="downloads"
+            :downloads-is-empty="downloads.length === 0"
             data-cy="download-participant-level-results"
+            @download-results="downloadResults"
           />
           <download-results-button
             identifier="dataset-level"
-            :results="results"
-            :downloads="downloads"
+            :downloads-is-empty="downloads.length === 0"
             data-cy="download-dataset-level-results"
+            @download-results="downloadResults"
           />
         </div>
       </b-row>
@@ -164,6 +164,60 @@ export default {
       } else {
         this.downloads = this.downloads.filter((item) => item !== datasetUuid);
       }
+    },
+    generateTSVString(buttonIdentifier) {
+      const tsvRows = [];
+      const datasets = this.results.filter((res) => this.downloads.includes(res.dataset_uuid));
+
+      if (buttonIdentifier === 'participant-level') {
+        const headers = ['DatasetID', 'SubjectID', 'Age', 'Sex', 'Diagnosis', 'Assessment', 'SessionID', 'SessionPath', 'NumSessions', 'Modality'].join('\t');
+        tsvRows.push(headers);
+
+        datasets.forEach((res) => {
+          res.subject_data.forEach((subject) => {
+            tsvRows.push([
+              res.dataset_uuid,
+              subject.sub_id,
+              subject.age,
+              subject.sex,
+              subject.diagnosis?.join(', '),
+              subject.assessment?.join(', '),
+              subject.session_id,
+              subject.session_file_path,
+              subject.num_sessions,
+              subject.image_modal?.join(', '),
+            ].join('\t'));
+          });
+        });
+      } else {
+        const headers = ['DatasetID', 'DatasetName', 'PortalURI', 'NumMatchingSubjects', 'AvailableImageModalities'].join('\t');
+        tsvRows.push(headers);
+
+        datasets.forEach((res) => {
+          tsvRows.push([
+            res.dataset_uuid,
+            res.dataset_name.replace('\n', ' '),
+            res.dataset_portal_uri,
+            res.num_matching_subjects,
+            res.image_modals?.join(', '),
+          ].join('\t'));
+        });
+      }
+
+      return tsvRows.join('\n');
+    },
+
+    downloadResults(buttonIdentifier) {
+      const element = document.createElement('a');
+      const encodedTSV = encodeURIComponent(this.generateTSVString(buttonIdentifier));
+      element.setAttribute('href', `data:text/tab-separated-values;charset=utf-8,${encodedTSV}`);
+      element.setAttribute('download', `${buttonIdentifier}-results.tsv`);
+
+      element.style.display = 'none';
+      document.body.appendChild(element);
+
+      element.click();
+      document.body.removeChild(element);
     },
   },
 };

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -82,11 +82,28 @@
         />
       </b-list-group>
     </b-row>
-    <download-results-button
-      :results="results"
-      :downloads="downloads"
-      data-cy="download-results"
-    />
+    <b-col
+      v-if="displayResults"
+      class="d-flex flex-row-reverse"
+      style="margin-top: 1em;"
+    >
+      <b-row>
+        <div class="download-buttons-div d-flex">
+          <download-results-button
+            identifier="participant-level"
+            :results="results"
+            :downloads="downloads"
+            data-cy="download-participant-level-results"
+          />
+          <download-results-button
+            identifier="dataset-level"
+            :results="results"
+            :downloads="downloads"
+            data-cy="download-dataset-level-results"
+          />
+        </div>
+      </b-row>
+    </b-col>
   </b-col>
 </template>
 

--- a/cypress/component/DownloadResultsButton.cy.js
+++ b/cypress/component/DownloadResultsButton.cy.js
@@ -1,6 +1,7 @@
 import DownloadResultsButton from '../../components/DownloadResultsButton.vue';
 
 const props = {
+  identifier: 'participant-level',
   results: [
     {
       dataset: 'http://neurobagel.org/vocab/cool-dataset',
@@ -22,23 +23,38 @@ const props = {
 };
 
 describe('Download results button', () => {
-  it('Displays the disabled download results buttons', () => {
+  it('Displays the disabled participant-level download results button', () => {
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.visible').should('be.disabled');
+  });
+  it('Displays the disabled dataset-level download results button', () => {
+    props.identifier = 'dataset-level';
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.visible').should('be.disabled');
   });
-  it('Displays the enabled download results buttons', () => {
+  it('Displays the enabled download participant-level results button', () => {
+    props.identifier = 'participant-level';
     props.downloads = ['cool-dataset'];
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.visible').should('not.be.disabled');
+  });
+  it('Displays the enabled download dataset-level results button', () => {
+    props.identifier = 'dataset-level';
+    props.downloads = ['cool-dataset'];
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.visible').should('not.be.disabled');
   });
-  it('Displays the tooltips when the download results buttons are disabled', () => {
+  it('Displays the tooltips when the download participant-level results button is disabled', () => {
     props.downloads = [];
+    props.identifier = 'participant-level';
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
@@ -49,7 +65,13 @@ describe('Download results button', () => {
     cy.get('[data-cy="download-participant-level-results-button-tooltip"]')
       .should('be.visible')
       .trigger('mouseleave');
-
+  });
+  it('Displays the tooltips when the download dataset-level results button is disabled', () => {
+    props.downloads = [];
+    props.identifier = 'dataset-level';
+    cy.mount(DownloadResultsButton, {
+      propsData: props,
+    });
     cy.get('[data-cy="download-dataset-level-results-button"]')
       .first()
       .trigger('mouseenter', { force: true });

--- a/cypress/component/DownloadResultsButton.cy.js
+++ b/cypress/component/DownloadResultsButton.cy.js
@@ -2,24 +2,7 @@ import DownloadResultsButton from '../../components/DownloadResultsButton.vue';
 
 const props = {
   identifier: 'participant-level',
-  results: [
-    {
-      dataset: 'http://neurobagel.org/vocab/cool-dataset',
-      dataset_name: 'cool-dataset',
-      num_matching_subjects: 2,
-      subject_file_paths: ['cool-path', 'some-cool-path'],
-      image_modals: ['http://purl.org/nidash/nidm#T1Weighted', 'http://purl.org/nidash/nidm#T2Weighted'],
-    },
-    {
-      dataset: 'http://neurobagel.org/vocab/not-so-cool-dataset',
-      dataset_name: 'not-so-cool-dataset',
-      num_matching_subjects: 2,
-      subject_file_paths: ['not-so-cool-path', 'some-not-so-cool-path'],
-      image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
-    },
-
-  ],
-  downloads: [],
+  downloadsIsEmpty: true,
 };
 
 describe('Download results button', () => {
@@ -38,7 +21,7 @@ describe('Download results button', () => {
   });
   it('Displays the enabled download participant-level results button', () => {
     props.identifier = 'participant-level';
-    props.downloads = ['cool-dataset'];
+    props.downloadsIsEmpty = false;
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
@@ -46,14 +29,13 @@ describe('Download results button', () => {
   });
   it('Displays the enabled download dataset-level results button', () => {
     props.identifier = 'dataset-level';
-    props.downloads = ['cool-dataset'];
+    props.downloadsIsEmpty = false;
     cy.mount(DownloadResultsButton, {
       propsData: props,
     });
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.visible').should('not.be.disabled');
   });
   it('Displays the tooltips when the download participant-level results button is disabled', () => {
-    props.downloads = [];
     props.identifier = 'participant-level';
     cy.mount(DownloadResultsButton, {
       propsData: props,
@@ -67,7 +49,6 @@ describe('Download results button', () => {
       .trigger('mouseleave');
   });
   it('Displays the tooltips when the download dataset-level results button is disabled', () => {
-    props.downloads = [];
     props.identifier = 'dataset-level';
     cy.mount(DownloadResultsButton, {
       propsData: props,
@@ -78,5 +59,17 @@ describe('Download results button', () => {
 
     cy.get('[data-cy="download-dataset-level-results-button-tooltip"]')
       .should('be.visible');
+  });
+  it('Emits download-results event when the button is clicked', () => {
+    props.identifier = 'participant-level';
+    props.downloadsIsEmpty = false;
+    cy.mount(DownloadResultsButton, {
+      listeners: {
+        'download-results': cy.spy().as('spy'),
+      },
+      propsData: props,
+    });
+    cy.get('[data-cy="download-participant-level-results-button"]').click();
+    cy.get('@spy').should('have.been.calledWith', 'participant-level');
   });
 });

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -83,7 +83,8 @@ describe('Results', () => {
       stubs,
       propsData: props,
     });
-    cy.get('[data-cy="download-results"]').should('be.visible');
+    cy.get('[data-cy="download-participant-level-results"]').should('be.visible');
+    cy.get('[data-cy="download-dataset-level-results"]').should('be.visible');
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="select-all"]').check();

--- a/cypress/e2e/ResultsTSV.cy.js
+++ b/cypress/e2e/ResultsTSV.cy.js
@@ -17,7 +17,7 @@ describe('Results TSV', () => {
     cy.get('[data-cy="submit-query"]').click();
     cy.get('[data-cy="select-all"]').check();
     cy.get('[data-cy="download-dataset-level-results-button"]').click();
-    cy.readFile('cypress/downloads/dataset-results.tsv').should('contain', 'some name');
+    cy.readFile('cypress/downloads/dataset-level-results.tsv').should('contain', 'some name');
   });
   it('Removes the unwanted whitespace from the downloaded results files', () => {
     cy.viewport(2000, 1000);
@@ -26,11 +26,11 @@ describe('Results TSV', () => {
     cy.get('[data-cy="submit-query"]').click();
     cy.get('[data-cy="select-all"]').check();
     cy.get('[data-cy="download-dataset-level-results-button"]').click();
-    cy.readFile('cypress/downloads/dataset-results.tsv').then((fileContent) => {
+    cy.readFile('cypress/downloads/dataset-level-results.tsv').then((fileContent) => {
       expect(fileContent).to.match(/^DatasetID/);
     });
     cy.get('[data-cy="download-participant-level-results-button"]').click();
-    cy.readFile('cypress/downloads/participant-results.tsv').then((fileContent) => {
+    cy.readFile('cypress/downloads/participant-level-results.tsv').then((fileContent) => {
       expect(fileContent).to.match(/^DatasetID/);
     });
   });


### PR DESCRIPTION
Closes #146 

Changes proposed in this pull request:

- Refactored `DownloadResultsButton` into a generic component
  - Removed `b-col`, `b-row`, `div` containers
  - Removed duplicate code
  - Removed `displayDownloadResultsButton` computed property
  - Implemented `identifier` prop
  - Updated `downloadResults` method
- Updated `ResultsContainer` component
    - Implemented a second `download-results-button` to the template
    - Implemented container elements for `download-results-button` elements
- Updated styles
- Updated related tests
- Secondary refactors (after 1st review):
  - Moved `generateTSVString` and `downloadResults` methods from
`DownloadResultsButton` to `ResultsContainer`
  - Removed `results` and `downloads` props in `DownloadResultsButton`
  - Added `downloadIsEmpty` prop in `DownloadResultsButton`
  - Removed `displayToolTip` method and moved the logic in line
  - Implemented `download-results` event in `DownloadResultsButton`
  - Updated `DownloadResultsButton` component test
  - Added a test case for `download-results` event

## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
