### PR TITLE
[ENH] Implemented example usage modal

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -128,6 +128,10 @@ input[type="checkbox"]:checked {
   background-color: #470A68;
 }
 
+.code {
+  color: #470A68;
+}
+
 /* Vue select */
 .vs__clear {
   display: flex;

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -93,7 +93,7 @@
             data-cy="example-usage-button"
             @click="$modal?.show('example-usage-modal')"
           >
-            Example usage
+            How to get the data
           </b-button>
           <modal
             name="example-usage-modal"

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -82,13 +82,38 @@
         />
       </b-list-group>
     </b-row>
-    <b-col
+    <b-row
       v-if="displayResults"
-      class="d-flex flex-row-reverse"
-      style="margin-top: 1em;"
+      style="margin-top: 1em"
     >
-      <b-row>
-        <div class="download-buttons-div d-flex">
+      <b-col cols="5">
+        <div class="d-flex justify-content-start">
+          <b-button
+            class="nb-button"
+            @click="$bvModal.show('example-usage-modal')"
+          >
+            Example usage
+          </b-button>
+          <b-modal
+            id="example-usage-modal"
+            title="Example usage"
+            hide-header-close
+            hide-footer
+            size="xl"
+          >
+            <p>Please follow these steps</p>
+            <ol>
+              <li>Select at least one dataset</li>
+              <li>Download the participant-level and dataset-level results</li>
+              <li>Change directory to the location of the downloaded files</li>
+              <li>Copy and run the following command:</li>
+            </ol>
+            <code class="code">{{ code }}</code>
+          </b-modal>
+        </div>
+      </b-col>
+      <b-col cols="7">
+        <div class="d-flex justify-content-end download-buttons-div">
           <download-results-button
             identifier="participant-level"
             :downloads-is-empty="downloads.length === 0"
@@ -102,8 +127,8 @@
             @download-results="downloadResults"
           />
         </div>
-      </b-row>
-    </b-col>
+      </b-col>
+    </b-row>
   </b-col>
 </template>
 
@@ -123,6 +148,7 @@ export default {
     return {
       selectAll: false,
       downloads: [],
+      code: 'docker run -t -v $(pwd):/data neurobagel/dataget:latest /data/dataset-results.tsv /data/participant-results.tsv /data/output',
     };
   },
   computed: {

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -91,28 +91,30 @@
           <b-button
             class="nb-button"
             data-cy="example-usage-button"
-            @click="$bvModal.show('example-usage-modal')"
+            @click="$modal?.show('example-usage-modal')"
           >
             Example usage
           </b-button>
-          <b-modal
-            id="example-usage-modal"
-            title="Example usage"
-            hide-header-close
-            hide-footer
-            centered
-            size="xl"
+          <modal
+            name="example-usage-modal"
+            :height="auto"
+            :adaptive="true"
+            :resizable="true"
+            :reset="true"
             data-cy="example-usage-modal"
           >
-            <p>Please follow these steps</p>
-            <ol>
-              <li>Select at least one dataset</li>
-              <li>Download the participant-level and dataset-level results</li>
-              <li>Change directory to the location of the downloaded files</li>
-              <li>Copy and run the following command:</li>
-            </ol>
-            <code class="code">{{ code }}</code>
-          </b-modal>
+            <div style="padding: 1em">
+              <h4>Example usage</h4>
+              <p>Please follow the steps below</p>
+              <ol>
+                <li>Select at least one dataset</li>
+                <li>Download the participant-level and dataset-level results files</li>
+                <li>Change directory to the location of the downloaded files</li>
+                <li>Copy and run the following command:</li>
+              </ol>
+              <code class="code">{{ code }}</code>
+            </div>
+          </modal>
         </div>
       </b-col>
       <b-col cols="7">

--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -90,6 +90,7 @@
         <div class="d-flex justify-content-start">
           <b-button
             class="nb-button"
+            data-cy="example-usage-button"
             @click="$bvModal.show('example-usage-modal')"
           >
             Example usage
@@ -99,7 +100,9 @@
             title="Example usage"
             hide-header-close
             hide-footer
+            centered
             size="xl"
+            data-cy="example-usage-modal"
           >
             <p>Please follow these steps</p>
             <ol>

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,8 +2,8 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   component: {
-    viewportWidth: 2000,
-    viewportHeight: 1000,
+    viewportWidth: 1280,
+    viewportHeight: 1024,
     devServer: {
       framework: "nuxt",
       bundler: "webpack",
@@ -11,8 +11,8 @@ module.exports = defineConfig({
   },
 
   e2e: {
-    viewportWidth: 2000,
-    viewportHeight: 1000,
+    viewportWidth: 1280,
+    viewportHeight: 1024,
     baseUrl: "http://localhost:3000",
     
     setupNodeEvents(on, config) {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,8 @@ module.exports = defineConfig({
   },
 
   e2e: {
+    viewportWidth: 2000,
+    viewportHeight: 1000,
     baseUrl: "http://localhost:3000",
     
     setupNodeEvents(on, config) {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,8 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   component: {
+    viewportWidth: 2000,
+    viewportHeight: 1000,
     devServer: {
       framework: "nuxt",
       bundler: "webpack",

--- a/cypress/component/ResultCard.cy.js
+++ b/cypress/component/ResultCard.cy.js
@@ -20,7 +20,6 @@ describe('Result card', () => {
     cy.get('[data-cy="card-http://neurobagel.org/vocab/cool-dataset-checkbox"]').should('be.visible').should('be.checked');
   });
   it('Emits update-download when a checkbox is checked/unchecked', () => {
-    cy.viewport(2000, 1000);
     cy.mount(ResultCard, {
       listeners: {
         'update-downloads': cy.spy().as('spy'),

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -96,18 +96,18 @@ describe('Results', () => {
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
   });
-  it('Displays the example usage button and modal', () => {
+  it('Displays the example usage button and modal and checks the modal content', () => {
     cy.mount(ResultsContainer, {
       stubs,
       propsData: props,
     });
     cy.get('[data-cy="example-usage-button"]').should('be.visible').click();
-    cy.get('#example-usage-modal___BV_modal_outer_')
-      .find('#example-usage-modal')
-    // .find('.modal-dialog modal-xl modal-dialog-centered')
-      .children()
-      .find('#example-usage-modal___BV_modal_content_')
-      .find('#example-usage-modal___BV_modal_body_')
-      .should('contain', 'Please follow these steps');
+    cy.get('[data-cy="example-usage-modal"]').should('be.visible');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Please follow the steps below');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Select at least one dataset');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Download the participant-level and dataset-level results files');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Change directory to the location of the downloaded files');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Copy and run the following command:');
+    cy.get('[data-cy="example-usage-modal"]').should('contain', 'docker run -t -v $(pwd):/data neurobagel/dataget:latest /data/dataset-results.tsv /data/participant-results.tsv /data/output');
   });
 });

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -78,7 +78,6 @@ describe('Results', () => {
     cy.get('[data-cy="http://neurobagel.org/vocab/not-so-cool-dataset"]').should('be.visible');
   });
   it('Displays download results buttons (and its component) and enables/disables it by checking/unchecking checkboxes', () => {
-    cy.viewport(2000, 1000);
     cy.mount(ResultsContainer, {
       stubs,
       propsData: props,
@@ -96,5 +95,19 @@ describe('Results', () => {
     cy.get('[data-cy="card-http://neurobagel.org/vocab/not-so-cool-dataset-checkbox"]').uncheck();
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
+  });
+  it('Displays the example usage button and modal', () => {
+    cy.mount(ResultsContainer, {
+      stubs,
+      propsData: props,
+    });
+    cy.get('[data-cy="example-usage-button"]').should('be.visible').click();
+    cy.get('#example-usage-modal___BV_modal_outer_')
+      .find('#example-usage-modal')
+    // .find('.modal-dialog modal-xl modal-dialog-centered')
+      .children()
+      .find('#example-usage-modal___BV_modal_content_')
+      .find('#example-usage-modal___BV_modal_body_')
+      .should('contain', 'Please follow these steps');
   });
 });

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -96,7 +96,7 @@ describe('Results', () => {
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
   });
-  it('Displays the example usage button and modal and checks the modal content', () => {
+  it('When results exist, displays example usage button and modal', () => {
     cy.mount(ResultsContainer, {
       stubs,
       propsData: props,
@@ -104,10 +104,5 @@ describe('Results', () => {
     cy.get('[data-cy="example-usage-button"]').should('be.visible').click();
     cy.get('[data-cy="example-usage-modal"]').should('be.visible');
     cy.get('[data-cy="example-usage-modal"]').should('contain', 'Please follow the steps below');
-    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Select at least one dataset');
-    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Download the participant-level and dataset-level results files');
-    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Change directory to the location of the downloaded files');
-    cy.get('[data-cy="example-usage-modal"]').should('contain', 'Copy and run the following command:');
-    cy.get('[data-cy="example-usage-modal"]').should('contain', 'docker run -t -v $(pwd):/data neurobagel/dataget:latest /data/dataset-results.tsv /data/participant-results.tsv /data/output');
   });
 });

--- a/cypress/component/ResultsContainer.cy.js
+++ b/cypress/component/ResultsContainer.cy.js
@@ -96,6 +96,14 @@ describe('Results', () => {
     cy.get('[data-cy="download-participant-level-results-button"]').should('be.disabled');
     cy.get('[data-cy="download-dataset-level-results-button"]').should('be.disabled');
   });
+  it('When results do not exist, example usage button and modal are not visible', () => {
+    cy.mount(ResultsContainer, {
+      stubs,
+      propsData: { ...props, results: [] },
+    });
+    cy.get('[data-cy="example-usage-button"]').should('not.exist');
+    cy.get('[data-cy="example-usage-modal"]').should('not.exist');
+  });
   it('When results exist, displays example usage button and modal', () => {
     cy.mount(ResultsContainer, {
       stubs,

--- a/cypress/e2e/Checkbox.cy.js
+++ b/cypress/e2e/Checkbox.cy.js
@@ -30,10 +30,6 @@ const response2 = [
 
 describe('Checkbox', () => {
   it('Unchecks checked checkboxes after a second query is run.', () => {
-    // Since the defualt viewport results in partial occlusion of the checkbox
-    // Set the viewport to 2000x1000 to ensure the checkbox is not covered and is cliclable
-    cy.viewport(2000, 1000);
-
     let isFirstClick = true;
 
     cy.intercept('GET', 'query/*', (req) => {

--- a/cypress/e2e/ResultsTSV.cy.js
+++ b/cypress/e2e/ResultsTSV.cy.js
@@ -11,7 +11,6 @@ const response = [
 
 describe('Results TSV', () => {
   it('Removes a newline character from a dataset name in the downloaded dataset-level results file', () => {
-    cy.viewport(2000, 1000);
     cy.intercept('query/?*', response).as('call');
     cy.visit('/');
     cy.get('[data-cy="submit-query"]').click();
@@ -20,7 +19,6 @@ describe('Results TSV', () => {
     cy.readFile('cypress/downloads/dataset-level-results.tsv').should('contain', 'some name');
   });
   it('Removes the unwanted whitespace from the downloaded results files', () => {
-    cy.viewport(2000, 1000);
     cy.intercept('query/?*', response).as('call');
     cy.visit('/');
     cy.get('[data-cy="submit-query"]').click();

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -31,6 +31,7 @@ export default {
   plugins: [
     '@plugins/bootstrap-vue',
     '@plugins/vue-select',
+    { src: '@plugins/vue-js-modal', ssr: false },
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "core-js": "^3.32.0",
         "nuxt": "^2.17.1",
         "vue": "^2.7.10",
+        "vue-js-modal": "^2.0.1",
         "vue-select": "^3.20.2",
         "vue-server-renderer": "^2.7.10",
         "vue-template-compiler": "^2.7.10"
@@ -17625,6 +17626,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
@@ -19994,6 +20000,17 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
+    },
+    "node_modules/vue-js-modal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-js-modal/-/vue-js-modal-2.0.1.tgz",
+      "integrity": "sha512-5FUwsH2zoxRKX4a7wkFAqX0eITCcIMunJDEfIxzHs2bHw9o20+Iqm+uQvBcg1jkzyo1+tVgThR/7NGU8djbD8Q==",
+      "dependencies": {
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.11"
+      }
     },
     "node_modules/vue-loader": {
       "version": "15.10.1",
@@ -33889,6 +33906,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.22.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
@@ -35713,6 +35735,14 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
+    },
+    "vue-js-modal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-js-modal/-/vue-js-modal-2.0.1.tgz",
+      "integrity": "sha512-5FUwsH2zoxRKX4a7wkFAqX0eITCcIMunJDEfIxzHs2bHw9o20+Iqm+uQvBcg1jkzyo1+tVgThR/7NGU8djbD8Q==",
+      "requires": {
+        "resize-observer-polyfill": "^1.5.1"
+      }
     },
     "vue-loader": {
       "version": "15.10.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "core-js": "^3.32.0",
     "nuxt": "^2.17.1",
     "vue": "^2.7.10",
+    "vue-js-modal": "^2.0.1",
     "vue-select": "^3.20.2",
     "vue-server-renderer": "^2.7.10",
     "vue-template-compiler": "^2.7.10"

--- a/plugins/vue-js-modal.js
+++ b/plugins/vue-js-modal.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+import VModal from 'vue-js-modal';
+
+import 'vue-js-modal/dist/styles.css';
+
+Vue.use(VModal, { dynamic: true });


### PR DESCRIPTION
Closes #173

Changes proposed in this pull request:
- Refactored `ResultsContainer` component to implement `Example usage` button
- Added `vue-js-modal` as a plugin
- Implemented `Example usage` button and modal
- Implemented test case for `Example usage` button  and modal
- Set the default viewport for cypress component and e2e tests in `cypress.config.js`
   - Updated related tests

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
