### PR TITLE
[ENH] Have an informative participants level .tsv if API is running in aggregate mode

### DIFF
--- a/components/ResultsContainer.vue
+++ b/components/ResultsContainer.vue
@@ -214,15 +214,15 @@ export default {
           res.subject_data.forEach((subject) => {
             tsvRows.push([
               res.dataset_uuid,
-              subject.sub_id,
-              subject.age,
-              subject.sex,
-              subject.diagnosis?.join(', '),
-              subject.assessment?.join(', '),
-              subject.session_id,
+              res.records_protected ? 'protected' : subject.sub_id,
+              res.records_protected ? 'protected' : subject.age,
+              res.records_protected ? 'protected' : subject.sex,
+              res.records_protected ? 'protected' : subject.diagnosis?.join(', '),
+              res.records_protected ? 'protected' : subject.assessment?.join(', '),
+              res.records_protected ? 'protected' : subject.session_id,
               subject.session_file_path,
-              subject.num_sessions,
-              subject.image_modal?.join(', '),
+              res.records_protected ? 'protected' : subject.num_sessions,
+              res.records_protected ? 'protected' : subject.image_modal?.join(', '),
             ].join('\t'));
           });
         });

--- a/cypress/e2e/ResultsTSV.cy.js
+++ b/cypress/e2e/ResultsTSV.cy.js
@@ -1,12 +1,50 @@
 const response = [
   {
+    records_protected: true,
     dataset_uuid: 'https://someportal.org/datasets/ds0001',
     dataset_file_path: 'https://github.com/somethingDatasets/ds0001.git',
     dataset_name: 'some\nname',
     num_matching_subjects: 3,
-    subject_data: [],
+    subject_data: [
+      {
+        session_file_path: '/ds000011/sub-01',
+      },
+    ],
     image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
   },
+  {
+    records_protected: false,
+    dataset_uuid: 'https://someportal.org/datasets/ds0002',
+    dataset_file_path: 'https://github.com/somethingDatasets/ds0002.git',
+    dataset_name: 'some\ncoolname',
+    num_matching_subjects: 5,
+    subject_data: [
+      {
+        sub_id: 'sub-04',
+        session_id: 'ses-nb04',
+        num_sessions: '1',
+        age: '35.0',
+        sex: 'http://purl.bioontology.org/ontology/SNOMEDCT/248153007',
+        diagnosis: [
+          null,
+          null,
+          null,
+        ],
+        subject_group: null,
+        assessment: [
+          null,
+        ],
+        image_modal: [
+          'http://purl.org/nidash/nidm#T2Weighted',
+          'http://purl.org/nidash/nidm#T1Weighted',
+          'http://purl.org/nidash/nidm#FlowWeighted',
+        ],
+        session_file_path: '/ds000011/sub-04',
+      },
+    ],
+    image_modals: ['http://purl.org/nidash/nidm#FlowWeighted', 'http://purl.org/nidash/nidm#T1Weighted'],
+  },
+
 ];
 
 describe('Results TSV', () => {
@@ -30,6 +68,23 @@ describe('Results TSV', () => {
     cy.get('[data-cy="download-participant-level-results-button"]').click();
     cy.readFile('cypress/downloads/participant-level-results.tsv').then((fileContent) => {
       expect(fileContent).to.match(/^DatasetID/);
+    });
+  });
+  it('Checks whether the protected and unprotected datasets are correctly identified', () => {
+    cy.intercept('query/?*', response).as('call');
+    cy.visit('/');
+    cy.get('[data-cy="submit-query"]').click();
+    cy.get('[data-cy="select-all"]').check();
+    cy.get('[data-cy="download-dataset-level-results-button"]').click();
+    cy.get('[data-cy="download-participant-level-results-button"]').click();
+    cy.readFile('cypress/downloads/participant-level-results.tsv').then((fileContent) => {
+      const rows = fileContent.split('\n');
+
+      const datasetProtected = rows[1];
+      const datasetNotProtected = rows[2];
+
+      expect(datasetProtected.split('\t')[3]).to.equal('protected');
+      expect(datasetNotProtected.split('\t')[3]).to.equal('http://purl.bioontology.org/ontology/SNOMEDCT/248153007');
     });
   });
 });


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #218 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Updated `generateTSVString` function to use `records_protected` flag
- Added test for `records_protected` flag

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
