### PR TITLE
[ENH] Implemented new field query to allow for querying specific nodes

### DIFF
--- a/components/CategoricalField.vue
+++ b/components/CategoricalField.vue
@@ -13,6 +13,7 @@
       v-model="selected"
       :data-cy="`${name}-select`"
       :options="options"
+      :multiple="multiple"
       :disabled="disabled"
       @input="updateField"
     />
@@ -27,12 +28,16 @@ export default {
       required: true,
     },
     defaultSelected: {
-      type: String,
+      type: [String, Array],
       default: null,
     },
     options: {
       type: Array,
       default: () => [],
+    },
+    multiple: {
+      type: Boolean,
+      default: false,
     },
     disabled: {
       type: Boolean,

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -13,7 +13,7 @@
           <categorical-field
             v-if="isFederationAPI"
             name="Neurobagel graph database"
-            data-cy="nodes-field"
+            data-cy="node-field"
             :options="['All', ...Object.keys(nodes)]"
             multiple="true"
             default-selected="All"
@@ -107,11 +107,18 @@ export default {
       type: Object,
       required: true,
     },
+    isFederationAPI: {
+      type: Boolean,
+      default: true,
+    },
+    nodes: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   emits: ['update-response'],
   data() {
     return {
-      nodes: {},
       selectedNodes: [],
       minAge: null,
       maxAge: null,
@@ -122,18 +129,7 @@ export default {
       assessment: null,
       modality: null,
       isFetching: false,
-      isFederationAPI: true,
     };
-  },
-  async mounted() {
-    this.isFederationAPI = this.$config.isFederationAPI;
-    if (this.isFederationAPI) {
-      const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
-      this.nodes = response.data.reduce((acc, node) => ({
-        ...acc,
-        [node.NodeName]: node.ApiURL,
-      }), {});
-    }
   },
   methods: {
     updateField(name, input) {

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -12,7 +12,7 @@
         <b-form-row class="row">
           <categorical-field
             v-if="isFederationAPI"
-            name="Neurobagel graph database"
+            name="Neurobagel graph"
             data-cy="node-field"
             :options="['All', ...Object.keys(nodes)]"
             multiple="true"
@@ -155,7 +155,7 @@ export default {
         case 'Imaging modality':
           this.modality = this.categoricalOptions[name][input];
           break;
-        case 'Neurobagel graph database':
+        case 'Neurobagel graph':
           if (!input.includes('All')) {
             this.selectedNodeURLs = input.map((nodeName) => this.nodes[nodeName]);
           }

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -184,8 +184,8 @@ export default {
     async submitQuery() {
       this.isFetching = true;
       let url = `${this.$config.apiQueryURL}query/?`;
-      if (this.selectedNodes.length > 0) {
-        this.selectedNodes.forEach((node) => {
+      if (this.selectedNodeURLs.length > 0) {
+        this.selectedNodeURLs.forEach((node) => {
           url += `&node_url=${node}`;
         });
       }

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -119,7 +119,7 @@ export default {
   emits: ['update-response'],
   data() {
     return {
-      selectedNodes: [],
+      selectedNodeURLs: [],
       minAge: null,
       maxAge: null,
       sex: null,
@@ -157,7 +157,7 @@ export default {
           break;
         case 'Neurobagel graph database':
           if (!input.includes('All')) {
-            this.selectedNodes = input.map((el) => this.nodes[el]);
+            this.selectedNodeURLs = input.map((nodeName) => this.nodes[nodeName]);
           }
           break;
         default:

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -72,12 +72,12 @@ describe('Query form', () => {
     // See https://stackoverflow.com/questions/71295432/unable-to-see-toast-in-cypress/71301155#71301155
     cy.contains('#b-toaster-top-right', 'The value of maximum age field must be greater than or equal to the value of minimum age field');
   });
-  it('Checks the options in the `node fields`', () => {
+  it('Checks the options in the `node field`', () => {
     cy.mount(QueryForm, {
       stubs,
       propsData: props,
     });
-    cy.get('[data-cy="node-field"]').should('be.visible').click();
+    cy.get('[data-cy="node-field"]').click();
     cy.get('[data-cy="node-field"]').contains('All');
     cy.get('[data-cy="node-field"]').contains('someNode');
     cy.get('[data-cy="node-field"]').contains('anotherNode');

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -72,14 +72,4 @@ describe('Query form', () => {
     // See https://stackoverflow.com/questions/71295432/unable-to-see-toast-in-cypress/71301155#71301155
     cy.contains('#b-toaster-top-right', 'The value of maximum age field must be greater than or equal to the value of minimum age field');
   });
-  it('Checks the options in the `node field`', () => {
-    cy.mount(QueryForm, {
-      stubs,
-      propsData: props,
-    });
-    cy.get('[data-cy="node-field"]').click();
-    cy.get('[data-cy="node-field"]').contains('All');
-    cy.get('[data-cy="node-field"]').contains('someNode');
-    cy.get('[data-cy="node-field"]').contains('anotherNode');
-  });
 });

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -8,6 +8,10 @@ const stubs = {
 };
 
 const props = {
+  nodes: {
+    someNode: 'https://someNode.org',
+    anotherNode: 'https://anotherNode.org',
+  },
   categoricalOptions: {
     Sex: {
       All: null,
@@ -39,6 +43,7 @@ describe('Query form', () => {
       stubs,
       propsData: props,
     });
+    cy.get('[data-cy="node-field"]').should('be.visible');
     cy.get('[data-cy="min-age-field"]').should('be.visible');
     cy.get('[data-cy="max-age-field"]').should('be.visible');
     cy.get('[data-cy="diagnosis-field"]').should('be.visible');
@@ -66,5 +71,15 @@ describe('Query form', () => {
     cy.get('[data-cy="submit-query"]').click();
     // See https://stackoverflow.com/questions/71295432/unable-to-see-toast-in-cypress/71301155#71301155
     cy.contains('#b-toaster-top-right', 'The value of maximum age field must be greater than or equal to the value of minimum age field');
+  });
+  it('Checks the options in the `node fields`', () => {
+    cy.mount(QueryForm, {
+      stubs,
+      propsData: props,
+    });
+    cy.get('[data-cy="node-field"]').should('be.visible').click();
+    cy.get('[data-cy="node-field"]').contains('All');
+    cy.get('[data-cy="node-field"]').contains('someNode');
+    cy.get('[data-cy="node-field"]').contains('anotherNode');
   });
 });

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -54,6 +54,7 @@ export default {
   // Needed for environment variable to be visible in client-side code: https://v2.nuxt.com/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config/#migrating-to-the-nuxt-runtime-config-from-nuxtjsdotenv
   publicRuntimeConfig: {
     apiQueryURL: process.env.API_QUERY_URL,
+    isFederationAPI: process.env.IS_FEDERATION_API,
   },
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,6 +3,8 @@
     <b-row class="mx-auto">
       <query-form
         :categorical-options="categoricalOptions"
+        :is-federation-api="isFederationAPI"
+        :nodes="nodes"
         @update-response="updateResponse"
       />
       <results-container
@@ -17,6 +19,8 @@
 export default {
   data() {
     return {
+      nodes: {},
+      isFederationAPI: true,
       results: null,
       error: null,
       categoricalOptions: {
@@ -105,6 +109,17 @@ export default {
         },
       },
     };
+  },
+  async mounted() {
+    if (this.$config.isFederationAPI) {
+      this.isFederationAPI = this.$config.isFederationAPI;
+
+      const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
+      this.nodes = response.data.reduce((acc, node) => ({
+        ...acc,
+        [node.NodeName]: node.ApiURL,
+      }), {});
+    }
   },
   methods: {
     updateResponse(results, error) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -115,8 +115,8 @@ export default {
       this.isFederationAPI = this.$config.isFederationAPI;
 
       const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
-      this.nodes = response.data.reduce((acc, node) => ({
-        ...acc,
+      this.nodes = response.data.reduce((tempNodeArray, node) => ({
+        ...tempNodeArray,
         [node.NodeName]: node.ApiURL,
       }), {});
     }


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #267
- Closes #283 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added `isFederationAPI` env var
  - if `isFederationAPI` is `true`, `index.vue` makes a request to the `get nodes` endpoint and passes them as props along with the value of `isFederationAPI` to the `QueryForm`
- Implemented a UI element for selecting nodes
  - only rendered if the `isFederationAPI` is `true`
  - Receives its options as `node` prop from parent `index.vue` 
- Updated `QueryForm` component test


<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
