### PR TITLE
[FIX] pass multiple keyword to cat-field correctly

### DIFF
--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -15,7 +15,7 @@
             name="Neurobagel graph"
             data-cy="node-field"
             :options="['All', ...Object.keys(nodes)]"
-            multiple="true"
+            multiple=true
             default-selected="All"
             @update-categorical-field="updateField"
           />


### PR DESCRIPTION
We were passing a prop with boolean type as string. Probably because vue's eslint rules cannot make up their mind about how they want this passed (expect quotes, but want bool).

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->


<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- turn `"true"` to `true` to satisfy prop type checking
-

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
