### PR TITLE
[ENH] Encode selected query nodes as query parameters in URL

### DIFF
--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -129,7 +129,6 @@ export default {
   emits: ['update-response', 'select-nodes'],
   data() {
     return {
-      selectedNodeNames: [],
       minAge: null,
       maxAge: null,
       sex: null,
@@ -141,15 +140,7 @@ export default {
       isFetching: false,
     };
   },
-  computed: {
-    selectedNodeURLs() {
-      return this.selectedNodeNames.map((nodeName) => this.availableNodes[nodeName]);
-    },
-  },
   methods: {
-    nodeWasSelected(event) {
-      this.$emit('selectNodes', event);
-    },
     updateField(name, input) {
       switch (name) {
         case 'Min Age':
@@ -197,9 +188,9 @@ export default {
     async submitQuery() {
       this.isFetching = true;
       let url = `${this.$config.apiQueryURL}query/?`;
-      if (this.isFederationAPI && this.selectedNodeURLs.length > 0) {
+      if (this.isFederationAPI && this.selectedNodes.length > 0) {
         this.selectedNodeURLs.forEach((node) => {
-          url += `&node_url=${node}`;
+          url += `&node_url=${node.ApiURL}`;
         });
       }
       if (this.minAge) {

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -17,12 +17,12 @@
               Neurobagel Graph
             </label>
             <v-select
-              :value="selectedNodesArray"
+              :value="selectedNodes"
               data-cy="node-field"
-              :options="availableNodesArray"
+              :options="availableNodes"
               :multiple=true
-              label="name"
-              @input="$emit('selectNodes')"
+              label="NodeName"
+              @input="$emit('selectNodes', $event)"
             />
           </div>
           <b-form-group class="col-md-6">
@@ -118,12 +118,12 @@ export default {
       default: true,
     },
     availableNodes: {
-      type: Object,
-      default: () => {},
+      type: Array,
+      default: () => [],
     },
     selectedNodes: {
-      type: Object,
-      default: () => {},
+      type: Array,
+      default: () => [],
     },
   },
   emits: ['update-response', 'select-nodes'],
@@ -145,16 +145,6 @@ export default {
     selectedNodeURLs() {
       return this.selectedNodeNames.map((nodeName) => this.availableNodes[nodeName]);
     },
-    selectedNodesArray() {
-      return Object.keys(this.selectedNodes).map((nodeName) => ({
-        name: nodeName, url: this.selectedNodes[nodeName],
-      }));
-    },
-    availableNodesArray() {
-      return Object.keys(this.availableNodes).map((nodeName) => ({
-        name: nodeName, url: this.availableNodes[nodeName],
-      }));
-    },
   },
   watch: {
     selectedNodeNames(newNodeName) {
@@ -167,6 +157,9 @@ export default {
     },
   },
   methods: {
+    nodeWasSelected(event) {
+      this.$emit('selectNodes', event);
+    },
     updateField(name, input) {
       switch (name) {
         case 'Min Age':

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -11,7 +11,7 @@
       <b-form @submit.prevent="validateQueryForm">
         <b-form-row class="row">
           <div
-            v-if="isFederationAPI"
+            v-if="isFederationApi"
           >
             <label class="form-label">
               Neurobagel Graph
@@ -113,7 +113,7 @@ export default {
       type: Object,
       required: true,
     },
-    isFederationAPI: {
+    isFederationApi: {
       type: Boolean,
       default: true,
     },
@@ -188,7 +188,7 @@ export default {
     async submitQuery() {
       this.isFetching = true;
       let url = `${this.$config.apiQueryURL}query/?`;
-      if (this.isFederationAPI && this.selectedNodes.length > 0) {
+      if (this.isFederationApi && this.selectedNodes.length > 0) {
         this.selectedNodes.forEach((node) => {
           if (node.NodeName !== 'All') {
             url += `&node_url=${node.ApiURL}`;

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -141,11 +141,15 @@ export default {
     if (node) {
       if (typeof node === 'string') {
         // There is only one node in the URL query parameters
-        this.selected_nodes = Object.keys(this.neurobagel_nodes).includes(node) ? [node] : [];
+        if (node === 'All') {
+          this.selected_nodes = [node];
+        } else {
+          this.selected_nodes = Object.keys(this.neurobagel_nodes).includes(node) ? [node] : [];
+        }
       } else if (typeof node === 'object') {
         // There are multiple nodes in the URL query parameters
         this.selected_nodes = node.filter((nodeName) => Object.keys(this.neurobagel_nodes)
-          .includes(nodeName));
+          .includes(nodeName) || nodeName === 'All');
       }
     }
   },

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -130,25 +130,24 @@ export default {
     };
   },
   async fetch() {
-    console.log('fetching stuff');
     const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
     this.neurobagel_nodes = response.data.reduce((tempNodeArray, node) => ({
       ...tempNodeArray,
       [node.NodeName]: node.ApiURL,
     }), {});
-    console.log('Done fetching sites:', this.neurobagel_nodes);
+
     // Now handle the URL provided by the user
     const { node } = this.$route.query;
     if (node) {
       if (typeof node === 'string') {
         // There is only one node in the URL query parameters
-        this.selected_nodes = [node];
+        this.selected_nodes = Object.keys(this.neurobagel_nodes).includes(node) ? [node] : [];
       } else if (typeof node === 'object') {
         // There are multiple nodes in the URL query parameters
-        this.selected_nodes = node;
+        this.selected_nodes = node.filter((nodeName) => Object.keys(this.neurobagel_nodes)
+          .includes(nodeName));
       }
     }
-    console.log('now the selected nodes are', this.selected_nodes);
   },
   watch: {
     selected_nodes(newNodeName) {

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -146,16 +146,6 @@ export default {
       return this.selectedNodeNames.map((nodeName) => this.availableNodes[nodeName]);
     },
   },
-  watch: {
-    selectedNodeNames(newNodeName) {
-      if (this.isFederationAPI) {
-        this.$router.push({
-          path: this.$route.path,
-          query: { ...this.$route.query, node: newNodeName },
-        });
-      }
-    },
-  },
   methods: {
     nodeWasSelected(event) {
       this.$emit('selectNodes', event);

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -189,8 +189,10 @@ export default {
       this.isFetching = true;
       let url = `${this.$config.apiQueryURL}query/?`;
       if (this.isFederationAPI && this.selectedNodes.length > 0) {
-        this.selectedNodeURLs.forEach((node) => {
-          url += `&node_url=${node.ApiURL}`;
+        this.selectedNodes.forEach((node) => {
+          if (node.NodeName !== 'All') {
+            url += `&node_url=${node.ApiURL}`;
+          }
         });
       }
       if (this.minAge) {

--- a/cypress/e2e/APIRequest.cy.js
+++ b/cypress/e2e/APIRequest.cy.js
@@ -1,6 +1,11 @@
+import { mixedResponse } from '../fixtures/example-responses';
+
 describe('API request', () => {
   it('Intercepts the request sent to the API and asserts over the request url', () => {
-    cy.intercept('GET', 'query/?*').as('call');
+    cy.intercept({
+      method: 'GET',
+      url: 'query/?*',
+    }, mixedResponse).as('call');
     cy.visit('/');
     cy.get('[data-cy="Min Age-continuous-field-input"]').type('10');
     cy.get('[data-cy="Max Age-continuous-field-input"]').type('30');

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,7 @@
     <b-row class="mx-auto">
       <query-form
         :categorical-options="categoricalOptions"
-        :is-federation-api="isFederationAPI"
+        :is-federation-api="isFederationApi"
         :selected-nodes="selectedNodes"
         :available-nodes="availableNodes"
         @update-response="updateResponse"
@@ -113,7 +113,7 @@ export default {
     };
   },
   async fetch() {
-    if (this.isFederationAPI) {
+    if (this.isFederationApi) {
       // TODO: write a test for all these fancy things
       const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
       this.availableNodes = response.data;
@@ -166,7 +166,11 @@ export default {
     }
   },
   computed: {
-    isFederationAPI() {
+    isFederationApi() {
+      // We're naming the computed property isFederationApi (smallcaps API)
+      // because vue-linting rules require props to not be capitalized but
+      // hyphenated: is-federation-api. This gets converted to isFederationApi.
+      // So to keep things consistent, we call it isFederationApi here as well.
       return this.$config.isFederationAPI === undefined ? true : this.$config.isFederationAPI;
     },
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -136,7 +136,7 @@ export default {
           if (nodeName === 'All') {
             // "All" is a special node name and just means
             // that we select all known nodes
-            this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
+            this.selectTheAllNode();
           } else {
             this.selectedNodes = availableNodeNames.includes(nodeName)
               ? [{
@@ -161,7 +161,7 @@ export default {
       }
 
       if (this.selectedNodes.length === 0) {
-        this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
+        this.selectTheAllNode();
       }
     }
   },
@@ -177,6 +177,9 @@ export default {
           path: this.$route.path,
           query: { ...this.$route.query, node: newNode.map((node) => node.NodeName) },
         });
+      } else if (this.isFederationAPI && newNode.length === 0) {
+        // If all nodes are removed, we default to the "All" node
+        this.selectTheAllNode();
       }
     },
   },
@@ -187,6 +190,9 @@ export default {
     },
     selectNodes(nodes) {
       this.selectedNodes = nodes;
+    },
+    selectTheAllNode() {
+      this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
     },
   },
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -123,7 +123,6 @@ export default {
         NodeName: 'All',
         ApiURL: undefined,
       });
-      console.log('now we have nodes', this.availableNodes);
 
       // The first time we load the app, we will also check the URL
       // for valid query parameters that refer to selected nodes.
@@ -159,7 +158,9 @@ export default {
               }
             ));
         }
-      } else {
+      }
+
+      if (this.selectedNodes.length === 0) {
         this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
       }
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -172,12 +172,12 @@ export default {
   },
   watch: {
     selectedNodes(newNode) {
-      if (this.isFederationAPI && newNode.length > 0) {
+      if (newNode.length > 0) {
         this.$router.push({
           path: this.$route.path,
           query: { ...this.$route.query, node: newNode.map((node) => node.NodeName) },
         });
-      } else if (this.isFederationAPI && newNode.length === 0) {
+      } else if (newNode.length === 0) {
         // If all nodes are removed, we default to the "All" node
         this.selectTheAllNode();
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
         :selected-nodes="selectedNodes"
         :available-nodes="availableNodes"
         @update-response="updateResponse"
-        @select-nodes="selectNodes"
+        @selectNodes="selectNodes"
       />
       <results-container
         :results="results"
@@ -21,8 +21,8 @@
 export default {
   data() {
     return {
-      availableNodes: {},
-      selectedNodes: {},
+      availableNodes: [],
+      selectedNodes: [],
       results: null,
       error: null,
       categoricalOptions: {
@@ -115,11 +115,13 @@ export default {
   async fetch() {
     if (this.isFederationAPI) {
       const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
-      this.availableNodes = response.data.reduce((tempNodeArray, node) => ({
-        ...tempNodeArray,
-        [node.NodeName]: node.ApiURL,
-      }), { All: undefined });
-      console.log('I just read in', this.availableNodes);
+      this.availableNodes = response.data;
+      // We need to also add out special "All" node
+      // that we use to select all nodes.
+      this.availableNodes.push({
+        NodeName: 'All',
+        ApiURL: undefined,
+      });
 
       // The first time we load the app, we will also check the URL
       // for valid query parameters that refer to selected nodes.
@@ -168,7 +170,7 @@ export default {
     },
     selectNodes(nodes) {
       console.log('here are the nodes we now have:', nodes);
-      this.selectedNodes = nodes;
+      // this.selectedNodes = nodes;
     },
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -116,7 +116,7 @@ export default {
     if (this.isFederationAPI) {
       const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
       this.availableNodes = response.data;
-      // We need to also add out special "All" node
+      // We need to also add our special "All" node
       // that we use to select all nodes.
       this.availableNodes.push({
         NodeName: 'All',
@@ -130,31 +130,29 @@ export default {
       const { node: nodeName } = this.$route.query;
       console.log('I found query node:', nodeName);
       if (nodeName !== undefined) {
+        const availableNodeNames = this.availableNodes.map((node) => node.NodeName);
         if (typeof nodeName === 'string') {
           // There is only one node in the URL query parameters
           if (nodeName === 'All') {
             // "All" is a special node name and just means
             // that we select all known nodes
-            this.selectedNodes = { All: undefined };
+            this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
           } else {
-            this.selectedNodes = Object.keys(this.availableNodes).includes(nodeName)
-              ? { [nodeName]: this.availableNodes[nodeName] }
-              : {};
+            this.selectedNodes = availableNodeNames.includes(nodeName)
+              ? [{ NodeName: nodeName, ApiURL: this.availableNodes[nodeName] }]
+              : [];
           }
         } else if (typeof nodeName === 'object') {
           // There are multiple nodes in the URL query parameters
           // We don't know if the user provided something silly or
           // a node that we no longer know about, so we need to filter.
-          this.selectedNodes = Object.keys(this.availableNodes)
-            .filter((availableNodeName) => nodeName.includes(availableNodeName))
-            .reduce((newObject, availableNodeName) => Object.assign(
-              newObject,
-              { [availableNodeName]: this.availableNodes[availableNodeName] },
-            ), {});
+          this.selectedNodes = nodeName
+            .filter((name) => availableNodeNames.includes(name))
+            .map((name) => ({ NodeName: name, ApiURL: this.availableNodes[name] }));
         }
       }
     } else {
-      this.selectedNodes = { All: undefined };
+      this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
     }
     console.log('after all this, we now have', this.selectedNodes);
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -123,6 +123,7 @@ export default {
         NodeName: 'All',
         ApiURL: undefined,
       });
+      console.log('now we have nodes', this.availableNodes);
 
       // The first time we load the app, we will also check the URL
       // for valid query parameters that refer to selected nodes.
@@ -139,7 +140,10 @@ export default {
             this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
           } else {
             this.selectedNodes = availableNodeNames.includes(nodeName)
-              ? [{ NodeName: nodeName, ApiURL: this.availableNodes[nodeName] }]
+              ? [{
+                NodeName: nodeName,
+                ApiURL: this.availableNodes[availableNodeNames.indexOf(nodeName)].ApiURL,
+              }]
               : [];
           }
         } else if (typeof nodeName === 'object') {
@@ -148,11 +152,16 @@ export default {
           // a node that we no longer know about, so we need to filter.
           this.selectedNodes = nodeName
             .filter((name) => availableNodeNames.includes(name))
-            .map((name) => ({ NodeName: name, ApiURL: this.availableNodes[name] }));
+            .map((name) => (
+              {
+                NodeName: name,
+                ApiURL: this.availableNodes[availableNodeNames.indexOf(name)].ApiURL,
+              }
+            ));
         }
+      } else {
+        this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
       }
-    } else {
-      this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
     }
   },
   computed: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -128,7 +128,6 @@ export default {
       // If we find any valid query parameters in the URL, then we
       // initialize the apps with these nodes selected!
       const { node: nodeName } = this.$route.query;
-      console.log('I found query node:', nodeName);
       if (nodeName !== undefined) {
         const availableNodeNames = this.availableNodes.map((node) => node.NodeName);
         if (typeof nodeName === 'string') {
@@ -154,7 +153,6 @@ export default {
     } else {
       this.selectedNodes = [{ NodeName: 'All', ApiURL: undefined }];
     }
-    console.log('after all this, we now have', this.selectedNodes);
   },
   computed: {
     isFederationAPI() {
@@ -167,8 +165,7 @@ export default {
       this.error = error;
     },
     selectNodes(nodes) {
-      console.log('here are the nodes we now have:', nodes);
-      // this.selectedNodes = nodes;
+      this.selectedNodes = nodes;
     },
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -114,6 +114,7 @@ export default {
   },
   async fetch() {
     if (this.isFederationAPI) {
+      // TODO: write a test for all these fancy things
       const response = await this.$axios.get(`${this.$config.apiQueryURL}nodes/`);
       this.availableNodes = response.data;
       // We need to also add our special "All" node
@@ -176,7 +177,6 @@ export default {
     },
     selectNodes(nodes) {
       this.selectedNodes = nodes;
-      console.log('now selected nodes are', this.selectedNodes);
     },
   },
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -159,6 +159,16 @@ export default {
       return this.$config.isFederationAPI === undefined ? true : this.$config.isFederationAPI;
     },
   },
+  watch: {
+    selectedNodes(newNode) {
+      if (this.isFederationAPI && newNode.length > 0) {
+        this.$router.push({
+          path: this.$route.path,
+          query: { ...this.$route.query, node: newNode.map((node) => node.NodeName) },
+        });
+      }
+    },
+  },
   methods: {
     updateResponse(results, error) {
       this.results = results;
@@ -166,8 +176,8 @@ export default {
     },
     selectNodes(nodes) {
       this.selectedNodes = nodes;
+      console.log('now selected nodes are', this.selectedNodes);
     },
   },
-
 };
 </script>


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #302

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- at the beginning of the lifecycle, right after reading node-list from f-API, parse the current browser URL for `node` query parameters
- if `node` query parameters exist, then see if they describe available nodes
- if they don't, default to the "All" node
- if they do, set these nodes to selected immediately
- make all of this reactive (i.e. if user selects nodes in dropdown, URL changes and vice versa)
- change how nodes are represented internally to be an array (of exactly the same shape as the response object from the f-API/nodes endpoint)
- work around the "All" node not having a defined ApiURL


**Note**: due to running out of brain juice this PR does not have any tests for this new functionality. That's a problem and we should fix it either before we merge or directly after. The challenging bit is going to be intercepting the URLs and environment variables.

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
