### PR TITLE
[ENH] add trailing slash to queryURL if none was added by user

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,5 +33,5 @@ module.exports = {
       },
     },
   ],
-  ignorePatterns: 'cypress.config.js',
+  ignorePatterns: ['cypress.config.js', 'dist/**', 'node_modules/**', '.nuxt/**'],
 };

--- a/components/QueryForm.vue
+++ b/components/QueryForm.vue
@@ -140,6 +140,12 @@ export default {
       isFetching: false,
     };
   },
+  computed: {
+    apiQueryURL() {
+      const url = this.$config.apiQueryURL;
+      return url.endsWith('/') ? `${url}query/?` : `${url}/query/?`;
+    },
+  },
   methods: {
     updateField(name, input) {
       switch (name) {
@@ -187,7 +193,7 @@ export default {
     },
     async submitQuery() {
       this.isFetching = true;
-      let url = `${this.$config.apiQueryURL}query/?`;
+      let url = this.apiQueryURL;
       if (this.isFederationApi && this.selectedNodes.length > 0) {
         this.selectedNodes.forEach((node) => {
           if (node.NodeName !== 'All') {

--- a/cypress/component/QueryForm.cy.js
+++ b/cypress/component/QueryForm.cy.js
@@ -141,4 +141,58 @@ describe('Query form', () => {
 
     cy.get('[data-cy="node-field"]').should('contain', 'anotherNode');
   });
+
+  it('Appends a slash to the apiQueryURL if it does not end with a slash', () => {
+    const getStub = cy.stub().resolves({ data: 'mock response' });
+
+    cy.mount(QueryForm, {
+      stubs,
+      propsData: {
+        selectedNodes: [
+          {
+            NodeName: 'anotherNode',
+            NodeURL: 'https://anotherNode.org',
+          },
+        ],
+        ...props,
+      },
+      mocks: {
+        $config: {
+          apiQueryURL: 'http://my.site.org',
+        },
+        $axios: {
+          get: getStub,
+        },
+      },
+    });
+    cy.get('[data-cy=submit-query]').click();
+    cy.wrap(getStub).should('have.been.calledWith', 'http://my.site.org/query/?&node_url=undefined');
+  });
+
+  it('Does not append extra slash to the apiQueryURL if it ends with a slash', () => {
+    const getStub = cy.stub().resolves({ data: 'mock response' });
+
+    cy.mount(QueryForm, {
+      stubs,
+      propsData: {
+        selectedNodes: [
+          {
+            NodeName: 'anotherNode',
+            NodeURL: 'https://anotherNode.org/',
+          },
+        ],
+        ...props,
+      },
+      mocks: {
+        $config: {
+          apiQueryURL: 'http://my.site.org',
+        },
+        $axios: {
+          get: getStub,
+        },
+      },
+    });
+    cy.get('[data-cy=submit-query]').click();
+    cy.wrap(getStub).should('have.been.calledWith', 'http://my.site.org/query/?&node_url=undefined');
+  });
 });


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #212 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- new test: the only good way to check if the internal parsing of apiQueryURL has worked is to first stub and then spy the axios.get call. So that's what I'm doing here
- I also taught `.eslint` to ignore the `dist/` dir because dist doesn't follow our styleguide and that makes eslint *very* upset

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
