### PR TITLE
[FIX] Fixed the URL parameter resetting in GItHub pages deployed app

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,6 +47,12 @@ export default {
       },
     };
   },
+  // According to Nuxt 2 docs https://v2.nuxt.com/docs/components-glossary/fetch/#nuxt--212,
+  // fetch hook can be used to get asynchronous data therefore we'll keep all logic related
+  // to fetching asynchronous data in this hook
+  // As we are currently deploying the app on Github Pages and using static site generation,
+  // fetch hook is only called during generation phase i.e., npm run generate and thus
+  // any logic related to updating the route would need to be moved to mounted hook
   async fetch() {
     const diagnosisResponse = await this.$axios.get(`${this.$config.apiQueryURL}attributes/nb:Diagnosis`);
     const diagnosisOptions = diagnosisResponse.data['nb:Diagnosis'].reduce((tempArray, diagnosis) => ({
@@ -99,10 +105,10 @@ export default {
     },
   },
   mounted() {
-    // The first time we load the app, we will also check the URL
+    // Once the component is mounted to DOM, check the URL
     // for valid query parameters that refer to selected nodes.
     // If we find any valid query parameters in the URL, then we
-    // initialize the apps with these nodes selected!
+    // update the app with these nodes selected!
     const { node: nodeName } = this.$route.query;
     if (nodeName !== undefined) {
       const availableNodeNames = this.availableNodes.map((node) => node.NodeName);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,7 +47,7 @@ export default {
       },
     };
   },
-  async mounted() {
+  async fetch() {
     const diagnosisResponse = await this.$axios.get(`${this.$config.apiQueryURL}attributes/nb:Diagnosis`);
     const diagnosisOptions = diagnosisResponse.data['nb:Diagnosis'].reduce((tempArray, diagnosis) => ({
       ...tempArray,
@@ -74,46 +74,6 @@ export default {
         NodeName: 'All',
         ApiURL: undefined,
       });
-
-      // The first time we load the app, we will also check the URL
-      // for valid query parameters that refer to selected nodes.
-      // If we find any valid query parameters in the URL, then we
-      // initialize the apps with these nodes selected!
-      const { node: nodeName } = this.$route.query;
-      if (nodeName !== undefined) {
-        const availableNodeNames = this.availableNodes.map((node) => node.NodeName);
-        if (typeof nodeName === 'string') {
-          // There is only one node in the URL query parameters
-          if (nodeName === 'All') {
-            // "All" is a special node name and just means
-            // that we select all known nodes
-            this.selectTheAllNode();
-          } else {
-            this.selectedNodes = availableNodeNames.includes(nodeName)
-              ? [{
-                NodeName: nodeName,
-                ApiURL: this.availableNodes[availableNodeNames.indexOf(nodeName)].ApiURL,
-              }]
-              : [];
-          }
-        } else if (typeof nodeName === 'object') {
-          // There are multiple nodes in the URL query parameters
-          // We don't know if the user provided something silly or
-          // a node that we no longer know about, so we need to filter.
-          this.selectedNodes = nodeName
-            .filter((name) => availableNodeNames.includes(name))
-            .map((name) => (
-              {
-                NodeName: name,
-                ApiURL: this.availableNodes[availableNodeNames.indexOf(name)].ApiURL,
-              }
-            ));
-        }
-      }
-
-      if (this.selectedNodes.length === 0) {
-        this.selectTheAllNode();
-      }
     }
   },
   computed: {
@@ -137,6 +97,47 @@ export default {
         this.selectTheAllNode();
       }
     },
+  },
+  mounted() {
+    // The first time we load the app, we will also check the URL
+    // for valid query parameters that refer to selected nodes.
+    // If we find any valid query parameters in the URL, then we
+    // initialize the apps with these nodes selected!
+    const { node: nodeName } = this.$route.query;
+    if (nodeName !== undefined) {
+      const availableNodeNames = this.availableNodes.map((node) => node.NodeName);
+      if (typeof nodeName === 'string') {
+        // There is only one node in the URL query parameters
+        if (nodeName === 'All') {
+          // "All" is a special node name and just means
+          // that we select all known nodes
+          this.selectTheAllNode();
+        } else {
+          this.selectedNodes = availableNodeNames.includes(nodeName)
+            ? [{
+              NodeName: nodeName,
+              ApiURL: this.availableNodes[availableNodeNames.indexOf(nodeName)].ApiURL,
+            }]
+            : [];
+        }
+      } else if (typeof nodeName === 'object') {
+        // There are multiple nodes in the URL query parameters
+        // We don't know if the user provided something silly or
+        // a node that we no longer know about, so we need to filter.
+        this.selectedNodes = nodeName
+          .filter((name) => availableNodeNames.includes(name))
+          .map((name) => (
+            {
+              NodeName: name,
+              ApiURL: this.availableNodes[availableNodeNames.indexOf(name)].ApiURL,
+            }
+          ));
+      }
+    }
+
+    if (this.selectedNodes.length === 0) {
+      this.selectTheAllNode();
+    }
   },
   methods: {
     updateResponse(results, error) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,10 +49,10 @@ export default {
   },
   // According to Nuxt 2 docs https://v2.nuxt.com/docs/components-glossary/fetch/#nuxt--212,
   // fetch hook can be used to get asynchronous data therefore we'll keep all logic related
-  // to fetching asynchronous data in this hook
-  // As we are currently deploying the app on Github Pages and using static site generation,
-  // fetch hook is only called during generation phase i.e., npm run generate and thus
-  // any logic related to updating the route would need to be moved to mounted hook
+  // to fetching asynchronous data in this hook.
+  // Since we are currently deploying the app on Github Pages and using static site generation,
+  // fetch hook is only called during the generation phase thus any logic related to
+  // updating the route would need to be moved to mounted hook
   async fetch() {
     const diagnosisResponse = await this.$axios.get(`${this.$config.apiQueryURL}attributes/nb:Diagnosis`);
     const diagnosisOptions = diagnosisResponse.data['nb:Diagnosis'].reduce((tempArray, diagnosis) => ({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,7 +47,7 @@ export default {
       },
     };
   },
-  async fetch() {
+  async mounted() {
     const diagnosisResponse = await this.$axios.get(`${this.$config.apiQueryURL}attributes/nb:Diagnosis`);
     const diagnosisOptions = diagnosisResponse.data['nb:Diagnosis'].reduce((tempArray, diagnosis) => ({
       ...tempArray,


### PR DESCRIPTION
According to Nuxt 2 docs https://v2.nuxt.com/docs/components-glossary/fetch/#nuxt--212, fetch hook can be used to get asynchronous data therefore we'll keep all logic related to fetching asynchronous data in this hook. Since we are currently deploying the app on Github Pages and using static site generation, fetch hook is only called during the generation phase i.e., `npm run generate` and thus any logic related to updating the route would need to be moved to the mounted hook which is run when the component is inserted into the DOM including when the app is initialized or reinitialized.

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
